### PR TITLE
Annotation helpers for PreferenceActivity and PreferenceFragment

### DIFF
--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/AfterPreferences.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/AfterPreferences.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+public @interface AfterPreferences {
+}

--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/AfterPreferences.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/AfterPreferences.java
@@ -20,6 +20,44 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * <p>
+ * Methods annotated with {@link AfterPreferences} will be called after
+ * <code>addPreferenceFromResource</code> is called by the generated classs.
+ * </p>
+ * <p>
+ * This occurs AFTER <code>addPreferencesFromResource</code> which is called at
+ * the end of super.onCreate(). Any preference depending code should be done in
+ * an {@link AfterPreferences} annotated method.
+ * </p>
+ * <p>
+ * The method MUST have zero parameters.
+ * </p>
+ * <p>
+ * There MAY be several methods annotated with {@link AfterPreferences} in the
+ * same class.
+ * </p>
+ * <blockquote>
+ *
+ * Example :
+ *
+ * <pre>
+ * &#064;EActivity
+ * public class SettingsActivity extends PreferenceActivity {
+ * 
+ * 	&#064;PreferenceByKey(R.string.checkBoxPref)
+ * 	CheckBoxPreference checkBoxPref;
+ * 
+ * 	&#064;AfterPreferences
+ * 	void initPrefs() {
+ * 		checkBoxPref.setChecked(false);
+ * 	}
+ * }
+ * </pre>
+ *
+ * </blockquote>
+ * 
+ */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.METHOD)
 public @interface AfterPreferences {

--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceByKey.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceByKey.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.FIELD)
+public @interface PreferenceByKey {
+
+	int value() default ResId.DEFAULT_VALUE;
+
+	String resName() default "";
+}

--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceByKey.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceByKey.java
@@ -20,6 +20,48 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * <p>
+ * Use it on a {@link android.preference.Preference Preference} or
+ * {@link android.preference.Preference Preference} subtype fields in a
+ * {@link org.androidannotations.annotations.EActivity EActivity} or
+ * {@link org.androidannotations.annotations.EFragment EFragment} annotated
+ * class, which is a subclass of {@link android.preference.PreferenceActivity
+ * PreferenceActivity} or <code>PreferenceFragment</code>, respectively.
+ * </p>
+ * <p>
+ * The annotation value should be an array of R.string.* fields.
+ * </p>
+ * <p>
+ * Your code related to injected views should go in an
+ * {@link org.androidannotations.annotations.AfterPreferences AfterPreferences}
+ * annotated method.
+ * </p>
+ * <blockquote>
+ *
+ * Example :
+ *
+ * <pre>
+ * &#064;EActivity
+ * public class SettingsActivity extends PreferenceActivity {
+ * 
+ * 	&#064;PreferenceByKey(R.string.myPref1)
+ * 	Preference myPreference1;
+ * 
+ * 	&#064;PreferenceByKey(R.string.checkBoxPref)
+ * 	CheckBoxPreference checkBoxPref;
+ * 
+ * 	&#064;AfterPreferences
+ * 	void initPrefs() {
+ * 		checkBoxPref.setChecked(false);
+ * 	}
+ * }
+ * </pre>
+ *
+ * </blockquote>
+ *
+ * @see org.androidannotations.annotations.AfterPreferences AfterPreferences
+ */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.FIELD)
 public @interface PreferenceByKey {

--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceChange.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceChange.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+public @interface PreferenceChange {
+
+	int[] value() default ResId.DEFAULT_VALUE;
+
+	String[] resName() default "";
+}

--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceChange.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceChange.java
@@ -20,6 +20,61 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * <p>
+ * This annotation is intended to be used on methods to receive events defined
+ * by
+ * {@link android.preference.Preference.OnPreferenceChangeListener#onPreferenceChange(android.preference.Preference, Object)
+ * OnPreferenceChangeListener#onPreferenceChange} when the value of a
+ * {@link android.preference.Preference Preference} has been changed by the user
+ * and is about to be set and/or persisted.
+ * </p>
+ * <p>
+ * The annotation value should be one or several R.string.* fields that refers
+ * to {@link android.preference.Preference Preference} or subclasses of
+ * {@link android.preference.Preference Preference}. If not set, the method name
+ * will be used as the R.string.* field name.
+ * </p>
+ * <p>
+ * The method MAY have multiple parameter:
+ * </p>
+ * <ul>
+ * <li>A {@link android.preference.Preference Preference} parameter to know
+ * which preference was targeted by this event</li>
+ * <li>An {@link Object} or {@link java.util.Set Set of strings} or
+ * {@link Boolean} or {@link String} to obtain the new value of the
+ * {@link android.preference.Preference Preference}</li>
+ * </ul>
+ * <blockquote>
+ * 
+ * Example :
+ * 
+ * <pre>
+ * &#064;PreferenceChange(<b>R.string.myPref</b>)
+ * void checkedChangedOnMyButton(boolean newValue, Preference preference) {
+ * 	// Something Here
+ * }
+ * 
+ * &#064;PreferenceChange
+ * void <b>myPref</b>PreferenceChanged(Preference preference) {
+ * 	// Something Here
+ * }
+ * 
+ * &#064;PreferenceChange(<b>{R.string.myPref1, R.string.myPref2}</b>)
+ * void preferenceChangeOnMultiplePrefs(Preference preference, String newValue) {
+ * 	// Something Here
+ * }
+ * 
+ * &#064;PreferenceChange(<b>R.string.myPref</b>)
+ * void preferenceChangeOnMyPref() {
+ * 	// Something Here
+ * }
+ * </pre>
+ * 
+ * </blockquote>
+ * 
+ * @see PreferenceClick
+ */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.METHOD)
 public @interface PreferenceChange {

--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceClick.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceClick.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+public @interface PreferenceClick {
+
+	int[] value() default ResId.DEFAULT_VALUE;
+
+	String[] resName() default "";
+}

--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceClick.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceClick.java
@@ -20,6 +20,46 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * <p>
+ * This annotation is intended to be used on methods to receive events defined
+ * by
+ * {@link android.preference.Preference.OnPreferenceClickListener#onPreferenceClick(android.preference.Preference)
+ * OnPreferenceClickListener#onPreferenceClick} when the
+ * {@link android.preference.Preference Preference} has been clicked by the
+ * user.
+ * </p>
+ * <p>
+ * The annotation value should be one or several of R.string.* fields. If not
+ * set, the method name will be used as the R.string.* field name.
+ * </p>
+ * <p>
+ * The method MAY have one parameter:
+ * </p>
+ * <ul>
+ * <li>A {@link android.preference.Preference Preference} parameter to know
+ * which preference has been clicked</li>
+ * </ul>
+ * <blockquote>
+ * 
+ * Example :
+ * 
+ * <pre>
+ * &#064;PreferenceClick(<b>R.string.myPref</b>)
+ * void clickOnMyPref() {
+ * 	// Something Here
+ * }
+ * 
+ * &#064;PreferenceClick
+ * void <b>myPref</b>PreferenceClicked(Preference preference) {
+ * 	// Something Here
+ * }
+ * </pre>
+ * 
+ * </blockquote>
+ * 
+ * @see PreferenceChange
+ */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.METHOD)
 public @interface PreferenceClick {

--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceHeaders.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceHeaders.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface PreferenceHeaders {
+
+	int value() default ResId.DEFAULT_VALUE;
+
+	String resName() default "";
+}

--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceHeaders.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceHeaders.java
@@ -20,6 +20,43 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * <p>
+ * Should be used on a {@link org.androidannotations.annotations.EActivity
+ * EActivity} class which is a subclass of
+ * {@link android.preference.PreferenceActivity PreferenceActivity}, to inject
+ * the preference headers from resource.
+ * </p>
+ * <p>
+ * The annotation value should be one of R.xml.* fields.
+ * </p>
+ * 
+ * <blockquote>
+ *
+ * Example :
+ *
+ * <pre>
+ * &#064;PreferenceHeaders(R.xml.preference_headers)
+ * &#064;EActivity
+ * public class SettingsActivity extends PreferenceActivity {
+ * 
+ * 	&#064;PreferenceByKey(R.string.myPref1)
+ * 	Preference myPreference1;
+ * 
+ * 	&#064;PreferenceByKey(R.string.checkBoxPref)
+ * 	CheckBoxPreference checkBoxPref;
+ * 
+ * 	&#064;AfterPreferences
+ * 	void initPrefs() {
+ * 		checkBoxPref.setChecked(false);
+ * 	}
+ * }
+ * </pre>
+ *
+ * </blockquote>
+ * 
+ * @see PreferenceScreen
+ */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)
 public @interface PreferenceHeaders {

--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceScreen.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceScreen.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface PreferenceScreen {
+
+	int value() default ResId.DEFAULT_VALUE;
+
+	String resName() default "";
+}

--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceScreen.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/annotations/PreferenceScreen.java
@@ -20,6 +20,44 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * <p>
+ * Should be used on {@link org.androidannotations.annotations.EActivity
+ * EActivity} or {@link org.androidannotations.annotations.EFragment EFragment}
+ * classes which are subclass of {@link android.preference.PreferenceActivity
+ * PreferenceActivity} or <code>PreferenceFragment</code>, to inject the
+ * preference screen from resource.
+ * </p>
+ * <p>
+ * The annotation value should be one of R.xml.* fields.
+ * </p>
+ * 
+ * <blockquote>
+ *
+ * Example :
+ *
+ * <pre>
+ * &#064;PreferenceScreen(R.xml.settings)
+ * &#064;EActivity
+ * public class SettingsActivity extends PreferenceActivity {
+ * 
+ * 	&#064;PreferenceByKey(R.string.myPref1)
+ * 	Preference myPreference1;
+ * 
+ * 	&#064;PreferenceByKey(R.string.checkBoxPref)
+ * 	CheckBoxPreference checkBoxPref;
+ * 
+ * 	&#064;AfterPreferences
+ * 	void initPrefs() {
+ * 		checkBoxPref.setChecked(false);
+ * 	}
+ * }
+ * </pre>
+ *
+ * </blockquote>
+ * 
+ * @see PreferenceHeaders
+ */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)
 public @interface PreferenceScreen {

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AbstractListenerHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AbstractListenerHandler.java
@@ -80,7 +80,7 @@ public abstract class AbstractListenerHandler extends BaseAnnotationHandler<ECom
 	@Override
 	public void process(Element element, EComponentWithViewSupportHolder holder) {
 		this.holder = holder;
-		this.methodName = element.getSimpleName().toString();
+		methodName = element.getSimpleName().toString();
 
 		ExecutableElement executableElement = (ExecutableElement) element;
 		List<? extends VariableElement> parameters = executableElement.getParameters();
@@ -103,7 +103,7 @@ public abstract class AbstractListenerHandler extends BaseAnnotationHandler<ECom
 
 		for (JFieldRef idRef : idsRefs) {
 			FoundViewHolder foundViewHolder = holder.getFoundViewHolder(idRef, getViewClass());
-			foundViewHolder.getIfNotNullBlock().invoke(foundViewHolder.getView(), getSetterName()).arg(_new(listenerAnonymousClass));
+			foundViewHolder.getIfNotNullBlock().invoke(foundViewHolder.getRef(), getSetterName()).arg(_new(listenerAnonymousClass));
 		}
 	}
 

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AbstractListenerHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AbstractListenerHandler.java
@@ -15,7 +15,6 @@
  */
 package org.androidannotations.handler;
 
-import static com.sun.codemodel.JExpr._new;
 import static com.sun.codemodel.JExpr.invoke;
 
 import java.util.List;
@@ -29,8 +28,7 @@ import javax.lang.model.type.TypeMirror;
 import org.androidannotations.helper.AndroidManifest;
 import org.androidannotations.helper.IdAnnotationHelper;
 import org.androidannotations.helper.IdValidatorHelper;
-import org.androidannotations.holder.EComponentWithViewSupportHolder;
-import org.androidannotations.holder.FoundViewHolder;
+import org.androidannotations.holder.GeneratedClassHolder;
 import org.androidannotations.model.AndroidSystemServices;
 import org.androidannotations.model.AnnotationElements;
 import org.androidannotations.process.IsValid;
@@ -44,10 +42,10 @@ import com.sun.codemodel.JFieldRef;
 import com.sun.codemodel.JInvocation;
 import com.sun.codemodel.JMethod;
 
-public abstract class AbstractListenerHandler extends BaseAnnotationHandler<EComponentWithViewSupportHolder> {
+public abstract class AbstractListenerHandler<T extends GeneratedClassHolder> extends BaseAnnotationHandler<T> {
 
 	private IdAnnotationHelper helper;
-	private EComponentWithViewSupportHolder holder;
+	private T holder;
 	private String methodName;
 
 	public AbstractListenerHandler(Class<?> targetClass, ProcessingEnvironment processingEnvironment) {
@@ -66,19 +64,17 @@ public abstract class AbstractListenerHandler extends BaseAnnotationHandler<ECom
 
 	@Override
 	public void validate(Element element, AnnotationElements validatedElements, IsValid valid) {
-		validatorHelper.enclosingElementHasEnhancedViewSupportAnnotation(element, validatedElements, valid);
-
-		validatorHelper.resIdsExist(element, IRClass.Res.ID, IdValidatorHelper.FallbackStrategy.USE_ELEMENT_NAME, valid);
+		validatorHelper.resIdsExist(element, getResourceType(), IdValidatorHelper.FallbackStrategy.USE_ELEMENT_NAME, valid);
 
 		validatorHelper.isNotPrivate(element, valid);
 
 		validatorHelper.doesntThrowException(element, valid);
 
-		validatorHelper.uniqueId(element, validatedElements, valid);
+		validatorHelper.uniqueResourceId(element, validatedElements, getResourceType(), valid);
 	}
 
 	@Override
-	public void process(Element element, EComponentWithViewSupportHolder holder) {
+	public void process(Element element, T holder) {
 		this.holder = holder;
 		methodName = element.getSimpleName().toString();
 
@@ -86,7 +82,7 @@ public abstract class AbstractListenerHandler extends BaseAnnotationHandler<ECom
 		List<? extends VariableElement> parameters = executableElement.getParameters();
 		TypeMirror returnType = executableElement.getReturnType();
 
-		List<JFieldRef> idsRefs = helper.extractAnnotationFieldRefs(processHolder, element, IRClass.Res.ID, true);
+		List<JFieldRef> idsRefs = helper.extractAnnotationFieldRefs(processHolder, element, getResourceType(), true);
 
 		JDefinedClass listenerAnonymousClass = codeModel().anonymousClass(getListenerClass());
 		JMethod listenerMethod = createListenerMethod(listenerAnonymousClass);
@@ -101,15 +97,14 @@ public abstract class AbstractListenerHandler extends BaseAnnotationHandler<ECom
 
 		processParameters(holder, listenerMethod, call, parameters);
 
-		for (JFieldRef idRef : idsRefs) {
-			FoundViewHolder foundViewHolder = holder.getFoundViewHolder(idRef, getViewClass());
-			foundViewHolder.getIfNotNullBlock().invoke(foundViewHolder.getRef(), getSetterName()).arg(_new(listenerAnonymousClass));
-		}
+		assignListeners(holder, idsRefs, listenerAnonymousClass);
 	}
+
+	protected abstract void assignListeners(T holder, List<JFieldRef> idsRefs, JDefinedClass listenerAnonymousClass);
 
 	protected abstract void makeCall(JBlock listenerMethodBody, JInvocation call, TypeMirror returnType);
 
-	protected abstract void processParameters(EComponentWithViewSupportHolder holder, JMethod listenerMethod, JInvocation call, List<? extends VariableElement> userParameters);
+	protected abstract void processParameters(T holder, JMethod listenerMethod, JInvocation call, List<? extends VariableElement> userParameters);
 
 	protected abstract JMethod createListenerMethod(JDefinedClass listenerAnonymousClass);
 
@@ -117,15 +112,15 @@ public abstract class AbstractListenerHandler extends BaseAnnotationHandler<ECom
 
 	protected abstract JClass getListenerClass();
 
-	protected JClass getViewClass() {
-		return classes().VIEW;
-	}
+	protected abstract JClass getListenerTargetClass();
 
 	protected String getMethodName() {
 		return methodName;
 	}
 
-	protected final EComponentWithViewSupportHolder getHolder() {
+	protected final T getHolder() {
 		return holder;
 	}
+
+	protected abstract IRClass.Res getResourceType();
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AbstractPreferenceListenerHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AbstractPreferenceListenerHandler.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.handler;
+
+import static com.sun.codemodel.JExpr._new;
+
+import java.util.List;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+
+import org.androidannotations.holder.FoundPreferenceHolder;
+import org.androidannotations.holder.HasPreferences;
+import org.androidannotations.model.AnnotationElements;
+import org.androidannotations.process.IsValid;
+import org.androidannotations.rclass.IRClass.Res;
+
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JFieldRef;
+
+public abstract class AbstractPreferenceListenerHandler extends AbstractListenerHandler<HasPreferences> {
+
+	public AbstractPreferenceListenerHandler(Class<?> targetClass, ProcessingEnvironment processingEnvironment) {
+		super(targetClass, processingEnvironment);
+	}
+
+	public AbstractPreferenceListenerHandler(String target, ProcessingEnvironment processingEnvironment) {
+		super(target, processingEnvironment);
+	}
+
+	@Override
+	public void validate(Element element, AnnotationElements validatedElements, IsValid valid) {
+		super.validate(element, validatedElements, valid);
+		validatorHelper.enclosingElementHasEActivityOrEFragment(element, validatedElements, valid);
+	}
+
+	@Override
+	protected final JClass getListenerTargetClass() {
+		return classes().PREFERENCE;
+	}
+
+	@Override
+	protected final Res getResourceType() {
+		return Res.STRING;
+	}
+
+	@Override
+	protected final void assignListeners(HasPreferences holder, List<JFieldRef> idsRefs, JDefinedClass listenerAnonymousClass) {
+		for (JFieldRef idRef : idsRefs) {
+			FoundPreferenceHolder foundPreferenceHolder = holder.getFoundPreferenceHolder(idRef, getListenerTargetClass());
+			foundPreferenceHolder.getIfNotNullBlock().invoke(foundPreferenceHolder.getRef(), getSetterName()).arg(_new(listenerAnonymousClass));
+		}
+	}
+
+}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AbstractViewListenerHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AbstractViewListenerHandler.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.handler;
+
+import static com.sun.codemodel.JExpr._new;
+
+import java.util.List;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+
+import org.androidannotations.holder.EComponentWithViewSupportHolder;
+import org.androidannotations.holder.FoundViewHolder;
+import org.androidannotations.model.AnnotationElements;
+import org.androidannotations.process.IsValid;
+import org.androidannotations.rclass.IRClass.Res;
+
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JFieldRef;
+
+public abstract class AbstractViewListenerHandler extends AbstractListenerHandler<EComponentWithViewSupportHolder> {
+
+	public AbstractViewListenerHandler(Class<?> targetClass, ProcessingEnvironment processingEnvironment) {
+		super(targetClass, processingEnvironment);
+	}
+
+	public AbstractViewListenerHandler(String target, ProcessingEnvironment processingEnvironment) {
+		super(target, processingEnvironment);
+	}
+
+	@Override
+	public void validate(Element element, AnnotationElements validatedElements, IsValid valid) {
+		super.validate(element, validatedElements, valid);
+		validatorHelper.enclosingElementHasEnhancedViewSupportAnnotation(element, validatedElements, valid);
+	}
+
+	@Override
+	protected final void assignListeners(EComponentWithViewSupportHolder holder, List<JFieldRef> idsRefs, JDefinedClass listenerAnonymousClass) {
+		for (JFieldRef idRef : idsRefs) {
+			FoundViewHolder foundViewHolder = holder.getFoundViewHolder(idRef, getListenerTargetClass());
+			foundViewHolder.getIfNotNullBlock().invoke(foundViewHolder.getRef(), getSetterName()).arg(_new(listenerAnonymousClass));
+		}
+	}
+
+	@Override
+	protected JClass getListenerTargetClass() {
+		return classes().VIEW;
+	}
+
+	@Override
+	protected final Res getResourceType() {
+		return Res.ID;
+	}
+
+}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AfterPreferencesHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AfterPreferencesHandler.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.handler;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+
+import org.androidannotations.annotations.AfterPreferences;
+import org.androidannotations.holder.HasPreferences;
+import org.androidannotations.model.AnnotationElements;
+import org.androidannotations.process.IsValid;
+
+public class AfterPreferencesHandler extends BaseAnnotationHandler<HasPreferences> {
+
+	public AfterPreferencesHandler(ProcessingEnvironment processingEnvironment) {
+		super(AfterPreferences.class, processingEnvironment);
+	}
+
+	@Override
+	public void validate(Element element, AnnotationElements validatedElements, IsValid valid) {
+		validatorHelper.enclosingElementHasEActivityOrEFragment(element, validatedElements, valid);
+		validatorHelper.enclosingElementExtendsPreferenceActivityOrPreferenceFragment(element, valid);
+
+		ExecutableElement executableElement = (ExecutableElement) element;
+
+		validatorHelper.returnTypeIsVoid(executableElement, valid);
+
+		validatorHelper.isNotPrivate(element, valid);
+
+		validatorHelper.doesntThrowException(executableElement, valid);
+
+		validatorHelper.param.zeroParameter(executableElement, valid);
+	}
+
+	@Override
+	public void process(Element element, HasPreferences holder) {
+		String methodName = element.getSimpleName().toString();
+		holder.getAddPreferencesFromResourceBlock().invoke(methodName);
+	}
+}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AnnotationHandlers.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AnnotationHandlers.java
@@ -129,6 +129,8 @@ public class AnnotationHandlers {
 
 		/* preference screen handler must be after injections */
 		add(new PreferenceScreenHandler(processingEnvironment));
+		/* Preference injections must be after preference screen handler */
+		add(new PreferenceByKeyHandler(processingEnvironment));
 
 		if (optionsHelper.shouldLogTrace()) {
 			add(new TraceHandler(processingEnvironment));

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AnnotationHandlers.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AnnotationHandlers.java
@@ -127,6 +127,9 @@ public class AnnotationHandlers {
 		add(new AfterExtrasHandler(processingEnvironment));
 		add(new AfterViewsHandler(processingEnvironment));
 
+		/* preference screen handler must be after injections */
+		add(new PreferenceScreenHandler(processingEnvironment));
+
 		if (optionsHelper.shouldLogTrace()) {
 			add(new TraceHandler(processingEnvironment));
 		}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AnnotationHandlers.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AnnotationHandlers.java
@@ -132,6 +132,7 @@ public class AnnotationHandlers {
 		/* Preference injections must be after preference screen handler */
 		add(new PreferenceByKeyHandler(processingEnvironment));
 		add(new PreferenceChangeHandler(processingEnvironment));
+		add(new PreferenceClickHandler(processingEnvironment));
 
 		if (optionsHelper.shouldLogTrace()) {
 			add(new TraceHandler(processingEnvironment));

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AnnotationHandlers.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AnnotationHandlers.java
@@ -129,6 +129,7 @@ public class AnnotationHandlers {
 
 		/* preference screen handler must be after injections */
 		add(new PreferenceScreenHandler(processingEnvironment));
+		add(new PreferenceHeadersHandler(processingEnvironment));
 		/* Preference injections must be after preference screen handler */
 		add(new PreferenceByKeyHandler(processingEnvironment));
 		add(new PreferenceChangeHandler(processingEnvironment));

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AnnotationHandlers.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AnnotationHandlers.java
@@ -133,6 +133,8 @@ public class AnnotationHandlers {
 		add(new PreferenceByKeyHandler(processingEnvironment));
 		add(new PreferenceChangeHandler(processingEnvironment));
 		add(new PreferenceClickHandler(processingEnvironment));
+		/* After preference injection methods must be after preference injections */
+		add(new AfterPreferencesHandler(processingEnvironment));
 
 		if (optionsHelper.shouldLogTrace()) {
 			add(new TraceHandler(processingEnvironment));

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AnnotationHandlers.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AnnotationHandlers.java
@@ -131,6 +131,7 @@ public class AnnotationHandlers {
 		add(new PreferenceScreenHandler(processingEnvironment));
 		/* Preference injections must be after preference screen handler */
 		add(new PreferenceByKeyHandler(processingEnvironment));
+		add(new PreferenceChangeHandler(processingEnvironment));
 
 		if (optionsHelper.shouldLogTrace()) {
 			add(new TraceHandler(processingEnvironment));

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/CheckedChangeHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/CheckedChangeHandler.java
@@ -38,7 +38,7 @@ import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JVar;
 
-public class CheckedChangeHandler extends AbstractListenerHandler {
+public class CheckedChangeHandler extends AbstractViewListenerHandler {
 
 	public CheckedChangeHandler(ProcessingEnvironment processingEnvironment) {
 		super(CheckedChange.class, processingEnvironment);
@@ -94,7 +94,7 @@ public class CheckedChangeHandler extends AbstractListenerHandler {
 	}
 
 	@Override
-	protected JClass getViewClass() {
+	protected JClass getListenerTargetClass() {
 		return classes().COMPOUND_BUTTON;
 	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ClickHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ClickHandler.java
@@ -36,7 +36,7 @@ import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JVar;
 
-public class ClickHandler extends AbstractListenerHandler {
+public class ClickHandler extends AbstractViewListenerHandler {
 
 	public ClickHandler(ProcessingEnvironment processingEnvironment) {
 		super(Click.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/EditorActionHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/EditorActionHandler.java
@@ -39,7 +39,7 @@ import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JVar;
 
-public class EditorActionHandler extends AbstractListenerHandler {
+public class EditorActionHandler extends AbstractViewListenerHandler {
 
 	public EditorActionHandler(ProcessingEnvironment processingEnvironment) {
 		super(EditorAction.class, processingEnvironment);
@@ -108,7 +108,7 @@ public class EditorActionHandler extends AbstractListenerHandler {
 	}
 
 	@Override
-	protected JClass getViewClass() {
+	protected JClass getListenerTargetClass() {
 		return classes().TEXT_VIEW;
 	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/FocusChangeHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/FocusChangeHandler.java
@@ -38,7 +38,7 @@ import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JVar;
 
-public class FocusChangeHandler extends AbstractListenerHandler {
+public class FocusChangeHandler extends AbstractViewListenerHandler {
 
 	public FocusChangeHandler(ProcessingEnvironment processingEnvironment) {
 		super(FocusChange.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ItemClickHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ItemClickHandler.java
@@ -41,7 +41,7 @@ import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JVar;
 
-public class ItemClickHandler extends AbstractListenerHandler {
+public class ItemClickHandler extends AbstractViewListenerHandler {
 
 	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
@@ -108,7 +108,7 @@ public class ItemClickHandler extends AbstractListenerHandler {
 	}
 
 	@Override
-	protected JClass getViewClass() {
+	protected JClass getListenerTargetClass() {
 		return classes().ADAPTER_VIEW.narrow(codeModel().wildcard());
 	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ItemLongClickHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ItemLongClickHandler.java
@@ -42,7 +42,7 @@ import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JVar;
 
-public class ItemLongClickHandler extends AbstractListenerHandler {
+public class ItemLongClickHandler extends AbstractViewListenerHandler {
 
 	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
@@ -115,7 +115,7 @@ public class ItemLongClickHandler extends AbstractListenerHandler {
 	}
 
 	@Override
-	protected JClass getViewClass() {
+	protected JClass getListenerTargetClass() {
 		return classes().ADAPTER_VIEW.narrow(codeModel().wildcard());
 	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ItemSelectHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ItemSelectHandler.java
@@ -43,7 +43,7 @@ import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JVar;
 
-public class ItemSelectHandler extends AbstractListenerHandler {
+public class ItemSelectHandler extends AbstractViewListenerHandler {
 
 	private JMethod onNothingSelectedMethod;
 
@@ -128,7 +128,7 @@ public class ItemSelectHandler extends AbstractListenerHandler {
 	}
 
 	@Override
-	protected JClass getViewClass() {
+	protected JClass getListenerTargetClass() {
 		return classes().ADAPTER_VIEW.narrow(codeModel().wildcard());
 	}
 

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/LongClickHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/LongClickHandler.java
@@ -38,7 +38,7 @@ import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JVar;
 
-public class LongClickHandler extends AbstractListenerHandler {
+public class LongClickHandler extends AbstractViewListenerHandler {
 
 	public LongClickHandler(ProcessingEnvironment processingEnvironment) {
 		super(LongClick.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceByKeyHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceByKeyHandler.java
@@ -52,7 +52,7 @@ public class PreferenceByKeyHandler extends BaseAnnotationHandler<HasPreferences
 	@Override
 	protected void validate(Element element, AnnotationElements validatedElements, IsValid valid) {
 		validatorHelper.enclosingElementHasEActivityOrEFragment(element, validatedElements, valid);
-		validatorHelper.extendsPreferenceActivityOrPreferenceFragment(element.getEnclosingElement(), valid);
+		validatorHelper.enclosingElementExtendsPreferenceActivityOrPreferenceFragment(element, valid);
 
 		validatorHelper.isDeclaredType(element, valid);
 

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceByKeyHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceByKeyHandler.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.handler;
+
+import static com.sun.codemodel.JExpr.ref;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.type.TypeMirror;
+
+import org.androidannotations.annotations.PreferenceByKey;
+import org.androidannotations.helper.AndroidManifest;
+import org.androidannotations.helper.IdAnnotationHelper;
+import org.androidannotations.helper.IdValidatorHelper;
+import org.androidannotations.holder.HasPreferences;
+import org.androidannotations.model.AndroidSystemServices;
+import org.androidannotations.model.AnnotationElements;
+import org.androidannotations.process.IsValid;
+import org.androidannotations.rclass.IRClass;
+
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JFieldRef;
+
+public class PreferenceByKeyHandler extends BaseAnnotationHandler<HasPreferences> {
+
+	private IdAnnotationHelper annotationHelper;
+
+	public PreferenceByKeyHandler(ProcessingEnvironment processingEnvironment) {
+		super(PreferenceByKey.class, processingEnvironment);
+
+	}
+
+	@Override
+	public void setAndroidEnvironment(IRClass rClass, AndroidSystemServices androidSystemServices, AndroidManifest androidManifest) {
+		super.setAndroidEnvironment(rClass, androidSystemServices, androidManifest);
+		annotationHelper = new IdAnnotationHelper(processingEnv, getTarget(), rClass);
+	}
+
+	@Override
+	protected void validate(Element element, AnnotationElements validatedElements, IsValid valid) {
+		validatorHelper.enclosingElementHasEActivityOrEFragment(element, validatedElements, valid);
+		validatorHelper.extendsPreferenceActivityOrPreferenceFragment(element.getEnclosingElement(), valid);
+
+		validatorHelper.isDeclaredType(element, valid);
+
+		validatorHelper.extendsPreference(element, valid);
+
+		validatorHelper.isNotPrivate(element, valid);
+
+		validatorHelper.resIdsExist(element, IRClass.Res.STRING, IdValidatorHelper.FallbackStrategy.USE_ELEMENT_NAME, valid);
+	}
+
+	@Override
+	public void process(Element element, HasPreferences holder) throws Exception {
+		String fieldName = element.getSimpleName().toString();
+
+		TypeMirror prefFieldTypeMirror = element.asType();
+		String typeQualifiedName = prefFieldTypeMirror.toString();
+
+		JFieldRef idRef = annotationHelper.extractOneAnnotationFieldRef(processHolder, element, IRClass.Res.STRING, true);
+		JClass preferenceClass = refClass(typeQualifiedName);
+		JFieldRef fieldRef = ref(fieldName);
+
+		holder.assignFindPreferenceByKey(idRef, preferenceClass, fieldRef);
+	}
+
+}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceChangeHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceChangeHandler.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.handler;
+
+import java.util.List;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+import org.androidannotations.annotations.PreferenceChange;
+import org.androidannotations.helper.APTCodeModelHelper;
+import org.androidannotations.helper.CanonicalNameConstants;
+import org.androidannotations.holder.HasPreferences;
+import org.androidannotations.model.AnnotationElements;
+import org.androidannotations.process.IsValid;
+
+import com.sun.codemodel.JBlock;
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JExpr;
+import com.sun.codemodel.JInvocation;
+import com.sun.codemodel.JMethod;
+import com.sun.codemodel.JMod;
+import com.sun.codemodel.JVar;
+
+public class PreferenceChangeHandler extends AbstractPreferenceListenerHandler {
+
+	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
+
+	public PreferenceChangeHandler(ProcessingEnvironment processingEnvironment) {
+		super(PreferenceChange.class, processingEnvironment);
+	}
+
+	@Override
+	public void validate(Element element, AnnotationElements validatedElements, IsValid valid) {
+		super.validate(element, validatedElements, valid);
+		validatorHelper.enclosingElementExtendsPreferenceActivityOrPreferenceFragment(element, valid);
+
+		ExecutableElement executableElement = (ExecutableElement) element;
+
+		validatorHelper.returnTypeIsVoidOrBoolean(executableElement, valid);
+
+		validatorHelper.param.hasNoOtherParameterThanPreferenceOrObjectOrSetOrStringOrBoolean(executableElement, valid);
+		validatorHelper.param.hasZeroOrOnePreferenceParameter(executableElement, valid);
+		validatorHelper.param.hasAtMostOneStringOrSetOrBooleanOrObjectParameter(executableElement, valid);
+	}
+
+	@Override
+	protected void makeCall(JBlock listenerMethodBody, JInvocation call, TypeMirror returnType) {
+		boolean returnMethodResult = returnType.getKind() != TypeKind.VOID;
+		if (returnMethodResult) {
+			listenerMethodBody._return(call);
+		} else {
+			listenerMethodBody.add(call);
+			listenerMethodBody._return(JExpr.TRUE);
+		}
+	}
+
+	@Override
+	protected void processParameters(HasPreferences holder, JMethod listenerMethod, JInvocation call, List<? extends VariableElement> userParameters) {
+		JVar preferenceParam = listenerMethod.param(classes().PREFERENCE, "preference");
+		JVar newValueParam = listenerMethod.param(classes().OBJECT, "newValue");
+
+		for (VariableElement variableElement : userParameters) {
+			if (variableElement.asType().toString().equals(CanonicalNameConstants.PREFERENCE)) {
+				call.arg(preferenceParam);
+			} else if (variableElement.asType().toString().equals(CanonicalNameConstants.OBJECT)) {
+				call.arg(newValueParam);
+			} else {
+				JClass userParamClass = codeModelHelper.typeMirrorToJClass(variableElement.asType(), holder);
+				call.arg(JExpr.cast(userParamClass, newValueParam));
+			}
+		}
+	}
+
+	@Override
+	protected JMethod createListenerMethod(JDefinedClass listenerAnonymousClass) {
+		return listenerAnonymousClass.method(JMod.PUBLIC, codeModel().BOOLEAN, "onPreferenceChange");
+	}
+
+	@Override
+	protected String getSetterName() {
+		return "setOnPreferenceChangeListener";
+	}
+
+	@Override
+	protected JClass getListenerClass() {
+		return classes().PREFERENCE_CHANGE_LISTENER;
+	}
+
+}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceClickHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceClickHandler.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.handler;
+
+import java.util.List;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+import org.androidannotations.annotations.PreferenceClick;
+import org.androidannotations.holder.HasPreferences;
+import org.androidannotations.model.AnnotationElements;
+import org.androidannotations.process.IsValid;
+
+import com.sun.codemodel.JBlock;
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JExpr;
+import com.sun.codemodel.JInvocation;
+import com.sun.codemodel.JMethod;
+import com.sun.codemodel.JMod;
+import com.sun.codemodel.JVar;
+
+public class PreferenceClickHandler extends AbstractPreferenceListenerHandler {
+
+	public PreferenceClickHandler(ProcessingEnvironment processingEnvironment) {
+		super(PreferenceClick.class, processingEnvironment);
+	}
+
+	@Override
+	public void validate(Element element, AnnotationElements validatedElements, IsValid valid) {
+		super.validate(element, validatedElements, valid);
+		validatorHelper.enclosingElementExtendsPreferenceActivityOrPreferenceFragment(element, valid);
+
+		ExecutableElement executableElement = (ExecutableElement) element;
+
+		validatorHelper.returnTypeIsVoidOrBoolean(executableElement, valid);
+
+		validatorHelper.param.zeroOrOnePreferenceParameter(executableElement, valid);
+	}
+
+	@Override
+	protected void makeCall(JBlock listenerMethodBody, JInvocation call, TypeMirror returnType) {
+		boolean returnMethodResult = returnType.getKind() != TypeKind.VOID;
+		if (returnMethodResult) {
+			listenerMethodBody._return(call);
+		} else {
+			listenerMethodBody.add(call);
+			listenerMethodBody._return(JExpr.TRUE);
+		}
+	}
+
+	@Override
+	protected void processParameters(HasPreferences holder, JMethod listenerMethod, JInvocation call, List<? extends VariableElement> userParameters) {
+		JVar preferenceParam = listenerMethod.param(classes().PREFERENCE, "preference");
+
+		if (userParameters.size() == 1) {
+			call.arg(preferenceParam);
+		}
+	}
+
+	@Override
+	protected JMethod createListenerMethod(JDefinedClass listenerAnonymousClass) {
+		return listenerAnonymousClass.method(JMod.PUBLIC, codeModel().BOOLEAN, "onPreferenceClick");
+	}
+
+	@Override
+	protected String getSetterName() {
+		return "setOnPreferenceClickListener";
+	}
+
+	@Override
+	protected JClass getListenerClass() {
+		return classes().PREFERENCE_CLICK_LISTENER;
+	}
+
+}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceHeadersHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceHeadersHandler.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.handler;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+
+import org.androidannotations.annotations.PreferenceHeaders;
+import org.androidannotations.helper.AnnotationHelper;
+import org.androidannotations.helper.IdValidatorHelper;
+import org.androidannotations.holder.HasPreferenceHeaders;
+import org.androidannotations.model.AnnotationElements;
+import org.androidannotations.process.IsValid;
+import org.androidannotations.rclass.IRClass;
+
+import com.sun.codemodel.JBlock;
+import com.sun.codemodel.JExpr;
+import com.sun.codemodel.JFieldRef;
+import com.sun.codemodel.JVar;
+
+public class PreferenceHeadersHandler extends BaseAnnotationHandler<HasPreferenceHeaders> {
+
+	private final AnnotationHelper annotationHelper;
+
+	public PreferenceHeadersHandler(ProcessingEnvironment processingEnvironment) {
+		super(PreferenceHeaders.class, processingEnvironment);
+		annotationHelper = new AnnotationHelper(processingEnvironment);
+	}
+
+	@Override
+	protected void validate(Element element, AnnotationElements validatedElements, IsValid valid) {
+		validatorHelper.isPreferenceFragmentClassPresent(element, valid);
+		validatorHelper.extendsPreferenceActivity(element, valid);
+		validatorHelper.hasEActivity(element, validatedElements, valid);
+		validatorHelper.resIdsExist(element, IRClass.Res.XML, IdValidatorHelper.FallbackStrategy.NEED_RES_ID, valid);
+	}
+
+	@Override
+	public void process(Element element, HasPreferenceHeaders holder) throws Exception {
+		JFieldRef headerId = annotationHelper.extractAnnotationFieldRefs(processHolder, element, getTarget(), rClass.get(IRClass.Res.XML), false).get(0);
+
+		JBlock block = holder.getOnBuildHeadersBlock();
+		JVar targetParam = holder.getOnBuildHeadersTargetParam();
+		block.invoke("loadHeadersFromResource").arg(headerId).arg(targetParam);
+		block.invoke(JExpr._super(), "onBuildHeaders").arg(targetParam);
+	}
+}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceScreenHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceScreenHandler.java
@@ -15,15 +15,11 @@
  */
 package org.androidannotations.handler;
 
-import java.util.Arrays;
-import java.util.List;
-
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 
 import org.androidannotations.annotations.PreferenceScreen;
 import org.androidannotations.helper.AnnotationHelper;
-import org.androidannotations.helper.CanonicalNameConstants;
 import org.androidannotations.helper.IdValidatorHelper;
 import org.androidannotations.holder.HasPreferences;
 import org.androidannotations.model.AnnotationElements;
@@ -34,8 +30,6 @@ import com.sun.codemodel.JFieldRef;
 
 public class PreferenceScreenHandler extends BaseAnnotationHandler<HasPreferences> {
 
-	private static final List<String> VALID_SUPER_CLASSES = Arrays.asList(CanonicalNameConstants.PREFERENCE_ACTIVITY, CanonicalNameConstants.PREFERENCE_FRAGMENT);
-
 	private final AnnotationHelper annotationHelper;
 
 	public PreferenceScreenHandler(ProcessingEnvironment processingEnvironment) {
@@ -45,7 +39,7 @@ public class PreferenceScreenHandler extends BaseAnnotationHandler<HasPreference
 
 	@Override
 	protected void validate(Element element, AnnotationElements validatedElements, IsValid valid) {
-		validatorHelper.extendsOneOfTypes(element, VALID_SUPER_CLASSES, valid);
+		validatorHelper.extendsPreferenceActivityOrPreferenceFragment(element, valid);
 		validatorHelper.hasEActivityOrEFragment(element, validatedElements, valid);
 		validatorHelper.resIdsExist(element, IRClass.Res.XML, IdValidatorHelper.FallbackStrategy.NEED_RES_ID, valid);
 	}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceScreenHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceScreenHandler.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.handler;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+
+import org.androidannotations.annotations.PreferenceScreen;
+import org.androidannotations.helper.AnnotationHelper;
+import org.androidannotations.helper.CanonicalNameConstants;
+import org.androidannotations.helper.IdValidatorHelper;
+import org.androidannotations.holder.HasPreferences;
+import org.androidannotations.model.AnnotationElements;
+import org.androidannotations.process.IsValid;
+import org.androidannotations.rclass.IRClass;
+
+import com.sun.codemodel.JFieldRef;
+
+public class PreferenceScreenHandler extends BaseAnnotationHandler<HasPreferences> {
+
+	private static final List<String> VALID_SUPER_CLASSES = Arrays.asList(CanonicalNameConstants.PREFERENCE_ACTIVITY, CanonicalNameConstants.PREFERENCE_FRAGMENT);
+
+	private final AnnotationHelper annotationHelper;
+
+	public PreferenceScreenHandler(ProcessingEnvironment processingEnvironment) {
+		super(PreferenceScreen.class, processingEnvironment);
+		annotationHelper = new AnnotationHelper(processingEnvironment);
+	}
+
+	@Override
+	protected void validate(Element element, AnnotationElements validatedElements, IsValid valid) {
+		validatorHelper.extendsOneOfTypes(element, VALID_SUPER_CLASSES, valid);
+		validatorHelper.hasEActivityOrEFragment(element, validatedElements, valid);
+		validatorHelper.resIdsExist(element, IRClass.Res.XML, IdValidatorHelper.FallbackStrategy.NEED_RES_ID, valid);
+	}
+
+	@Override
+	public void process(Element element, HasPreferences holder) throws Exception {
+		JFieldRef preferenceId = annotationHelper.extractAnnotationFieldRefs(processHolder, element, getTarget(), rClass.get(IRClass.Res.XML), false).get(0);
+
+		holder.getPreferenceScreenInitializationBlock().invoke("addPreferencesFromResource").arg(preferenceId);
+	}
+}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/TouchHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/TouchHandler.java
@@ -39,7 +39,7 @@ import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JVar;
 
-public class TouchHandler extends AbstractListenerHandler {
+public class TouchHandler extends AbstractViewListenerHandler {
 
 	public TouchHandler(ProcessingEnvironment processingEnvironment) {
 		super(Touch.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ViewsByIdHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ViewsByIdHandler.java
@@ -112,7 +112,7 @@ public class ViewsByIdHandler extends BaseAnnotationHandler<EComponentWithViewSu
 
 	private void addViewToListIfNotNull(JFieldRef elementRef, JClass viewClass, JFieldRef idRef, EComponentWithViewSupportHolder holder) {
 		FoundViewHolder foundViewHolder = holder.getFoundViewHolder(idRef, viewClass);
-		foundViewHolder.getIfNotNullBlock().invoke(elementRef, "add").arg(foundViewHolder.getView(viewClass));
+		foundViewHolder.getIfNotNullBlock().invoke(elementRef, "add").arg(foundViewHolder.getOrCastRef(viewClass));
 	}
 
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
@@ -109,6 +109,8 @@ public final class CanonicalNameConstants {
 	public static final String WAKE_LOCK = "android.os.PowerManager.WakeLock";
 	public static final String BUILD_VERSION = "android.os.Build.VERSION";
 	public static final String BUILD_VERSION_CODES = "android.os.Build.VERSION_CODES";
+	public static final String PREFERENCE_ACTIVITY = "android.preference.PreferenceActivity";
+	public static final String PREFERENCE_FRAGMENT = "android.preference.PreferenceFragment";
 	public static final String ACTIVITY_COMPAT = "android.support.v4.app.ActivityCompat";
 
 	/*

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
@@ -114,6 +114,7 @@ public final class CanonicalNameConstants {
 	public static final String ACTIVITY_COMPAT = "android.support.v4.app.ActivityCompat";
 	public static final String PREFERENCE = "android.preference.Preference";
 	public static final String PREFERENCE_CHANGE_LISTENER = "android.preference.Preference.OnPreferenceChangeListener";
+	public static final String PREFERENCE_CLICK_LISTENER = "android.preference.Preference.OnPreferenceClickListener";
 
 	/*
 	 * Android permission

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
@@ -112,6 +112,7 @@ public final class CanonicalNameConstants {
 	public static final String PREFERENCE_ACTIVITY = "android.preference.PreferenceActivity";
 	public static final String PREFERENCE_FRAGMENT = "android.preference.PreferenceFragment";
 	public static final String ACTIVITY_COMPAT = "android.support.v4.app.ActivityCompat";
+	public static final String PREFERENCE = "android.preference.Preference";
 
 	/*
 	 * Android permission

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
@@ -113,6 +113,7 @@ public final class CanonicalNameConstants {
 	public static final String PREFERENCE_FRAGMENT = "android.preference.PreferenceFragment";
 	public static final String ACTIVITY_COMPAT = "android.support.v4.app.ActivityCompat";
 	public static final String PREFERENCE = "android.preference.Preference";
+	public static final String PREFERENCE_CHANGE_LISTENER = "android.preference.Preference.OnPreferenceChangeListener";
 
 	/*
 	 * Android permission

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/IdValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/IdValidatorHelper.java
@@ -87,11 +87,11 @@ public class IdValidatorHelper extends ValidatorHelper {
 		}
 	}
 
-	public void uniqueId(Element element, AnnotationElements validatedElements, IsValid valid) {
+	public void uniqueResourceId(Element element, AnnotationElements validatedElements, Res resourceType, IsValid valid) {
 
 		if (valid.isValid()) {
 
-			List<String> annotationQualifiedIds = idAnnotationHelper.extractAnnotationResources(element, Res.ID, true);
+			List<String> annotationQualifiedIds = idAnnotationHelper.extractAnnotationResources(element, resourceType, true);
 
 			Element elementEnclosingElement = element.getEnclosingElement();
 			Set<? extends Element> annotatedElements = validatedElements.getRootAnnotatedElements(annotationHelper.getTarget());
@@ -101,7 +101,7 @@ public class IdValidatorHelper extends ValidatorHelper {
 
 				if (elementEnclosingElement.equals(uniqueCheckEnclosingElement)) {
 
-					List<String> checkQualifiedIds = idAnnotationHelper.extractAnnotationResources(uniqueCheckElement, Res.ID, true);
+					List<String> checkQualifiedIds = idAnnotationHelper.extractAnnotationResources(uniqueCheckElement, resourceType, true);
 
 					for (String checkQualifiedId : checkQualifiedIds) {
 						for (String annotationQualifiedId : annotationQualifiedIds) {
@@ -109,7 +109,7 @@ public class IdValidatorHelper extends ValidatorHelper {
 							if (annotationQualifiedId.equals(checkQualifiedId)) {
 								valid.invalidate();
 								String annotationSimpleId = annotationQualifiedId.substring(annotationQualifiedId.lastIndexOf('.') + 1);
-								annotationHelper.printAnnotationError(element, "The id " + annotationSimpleId + " is already used on the following " + annotationHelper.annotationName() + " method: " + uniqueCheckElement);
+								annotationHelper.printAnnotationError(element, "The resource id " + annotationSimpleId + " is already used on the following " + annotationHelper.annotationName() + " method: " + uniqueCheckElement);
 								return;
 							}
 						}
@@ -117,6 +117,10 @@ public class IdValidatorHelper extends ValidatorHelper {
 				}
 			}
 		}
+	}
+
+	public void uniqueId(Element element, AnnotationElements validatedElements, IsValid valid) {
+		uniqueResourceId(element, validatedElements, Res.ID, valid);
 	}
 
 	public void annotationValuePositiveAndInAShort(Element element, IsValid valid, int value) {

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
@@ -91,6 +91,7 @@ import org.androidannotations.model.AndroidSystemServices;
 import org.androidannotations.model.AnnotationElements;
 import org.androidannotations.process.IsValid;
 
+@SuppressWarnings("checkstyle:methodcount")
 public class ValidatorHelper {
 
 	private static final List<String> VALID_REST_INTERFACES = asList(RestClientHeaders.class.getName(), RestClientErrorHandling.class.getName(), RestClientRootUrl.class.getName(), RestClientSupport.class.getName());

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
@@ -1508,8 +1508,19 @@ public class ValidatorHelper {
 		extendsOneOfTypes(element, VALID_PREFERENCE_CLASSES, valid);
 	}
 
+	public void extendsPreferenceActivity(Element element, IsValid valid) {
+		extendsType(element, CanonicalNameConstants.PREFERENCE_ACTIVITY, valid);
+	}
+
 	public void enclosingElementExtendsPreferenceActivityOrPreferenceFragment(Element element, IsValid valid) {
 		extendsOneOfTypes(element.getEnclosingElement(), VALID_PREFERENCE_CLASSES, valid);
 	}
 
+	public void isPreferenceFragmentClassPresent(Element element, IsValid valid) {
+		TypeElement preferenceFragmentElement = annotationHelper.getElementUtils().getTypeElement(CanonicalNameConstants.PREFERENCE_FRAGMENT);
+
+		if (preferenceFragmentElement == null) {
+			annotationHelper.printAnnotationError(element, "The class " + CanonicalNameConstants.PREFERENCE_FRAGMENT + " cannot be found. You have to use at least API 11");
+		}
+	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
@@ -115,6 +115,8 @@ public class ValidatorHelper {
 	private static final List<Receiver.RegisterAt> VALID_SERVICE_REGISTER_AT = Arrays.asList(Receiver.RegisterAt.OnCreateOnDestroy);
 	private static final List<Receiver.RegisterAt> VALID_FRAGMENT_REGISTER_AT = Arrays.asList(Receiver.RegisterAt.OnCreateOnDestroy, Receiver.RegisterAt.OnResumeOnPause, Receiver.RegisterAt.OnStartOnStop, Receiver.RegisterAt.OnAttachOnDetach);
 
+	private static final List<String> VALID_PREFERENCE_CLASSES = asList(CanonicalNameConstants.PREFERENCE_ACTIVITY, CanonicalNameConstants.PREFERENCE_FRAGMENT);
+
 	protected final TargetAnnotationHelper annotationHelper;
 
 	public final ValidatorParameterHelper param;
@@ -581,6 +583,10 @@ public class ValidatorHelper {
 			valid.invalidate();
 			annotationHelper.printAnnotationError(element, "%s can only be used on a " + CanonicalNameConstants.LIST + " of elements extending " + CanonicalNameConstants.VIEW);
 		}
+	}
+
+	public void extendsPreference(Element element, IsValid valid) {
+		extendsType(element, CanonicalNameConstants.PREFERENCE, valid);
 	}
 
 	public void hasASqlLiteOpenHelperParameterizedType(Element element, IsValid valid) {
@@ -1496,6 +1502,10 @@ public class ValidatorHelper {
 				annotationHelper.printAnnotationError(element, "To use the LocalBroadcastManager, you MUST include the android-support-v4 jar");
 			}
 		}
+	}
+
+	public void extendsPreferenceActivityOrPreferenceFragment(Element element, IsValid valid) {
+		extendsOneOfTypes(element, VALID_PREFERENCE_CLASSES, valid);
 	}
 
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
@@ -1508,4 +1508,8 @@ public class ValidatorHelper {
 		extendsOneOfTypes(element, VALID_PREFERENCE_CLASSES, valid);
 	}
 
+	public void enclosingElementExtendsPreferenceActivityOrPreferenceFragment(Element element, IsValid valid) {
+		extendsOneOfTypes(element.getEnclosingElement(), VALID_PREFERENCE_CLASSES, valid);
+	}
+
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorParameterHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorParameterHelper.java
@@ -36,6 +36,7 @@ public class ValidatorParameterHelper {
 
 	private static final List<String> ANDROID_SHERLOCK_MENU_ITEM_QUALIFIED_NAMES = asList(CanonicalNameConstants.MENU_ITEM, CanonicalNameConstants.SHERLOCK_MENU_ITEM);
 	private static final List<String> EDITOR_ACTION_ALLOWED_PARAMETER_TYPES = asList(CanonicalNameConstants.TEXT_VIEW, CanonicalNameConstants.INTEGER, "int", CanonicalNameConstants.KEY_EVENT);
+	private static final List<String> PREFERENCE_CHANGE_ALLOWED_NEWVALUE_PARAM = asList(CanonicalNameConstants.OBJECT, CanonicalNameConstants.SET, CanonicalNameConstants.STRING, CanonicalNameConstants.BOOLEAN);
 
 	protected final TargetAnnotationHelper annotationHelper;
 
@@ -131,6 +132,10 @@ public class ValidatorParameterHelper {
 		hasZeroOrOneParameterOfType(CanonicalNameConstants.VIEW, executableElement, valid);
 	}
 
+	public void hasZeroOrOnePreferenceParameter(ExecutableElement executableElement, IsValid valid) {
+		hasZeroOrOneParameterOfType(CanonicalNameConstants.PREFERENCE, executableElement, valid);
+	}
+
 	private void hasZeroOrOneParameterOfType(String typeCanonicalName, ExecutableElement executableElement, IsValid valid) {
 		boolean parameterOfTypeFound = false;
 		for (VariableElement parameter : executableElement.getParameters()) {
@@ -170,6 +175,13 @@ public class ValidatorParameterHelper {
 
 	public void hasNoOtherParameterThanViewOrBoolean(ExecutableElement executableElement, IsValid valid) {
 		String[] types = new String[] { CanonicalNameConstants.VIEW, CanonicalNameConstants.BOOLEAN, "boolean" };
+		hasNotOtherParameterThanTypes(types, executableElement, valid);
+	}
+
+	public void hasNoOtherParameterThanPreferenceOrObjectOrSetOrStringOrBoolean(ExecutableElement executableElement, IsValid valid) {
+		String[] types = new String[PREFERENCE_CHANGE_ALLOWED_NEWVALUE_PARAM.size() + 1];
+		types = PREFERENCE_CHANGE_ALLOWED_NEWVALUE_PARAM.toArray(types);
+		types[types.length - 1] = CanonicalNameConstants.PREFERENCE;
 		hasNotOtherParameterThanTypes(types, executableElement, valid);
 	}
 
@@ -248,6 +260,10 @@ public class ValidatorParameterHelper {
 
 	}
 
+	public void hasAtMostOneStringOrSetOrBooleanOrObjectParameter(ExecutableElement executableElement, IsValid valid) {
+		hasAtMostOneSpecificParameter(executableElement, PREFERENCE_CHANGE_ALLOWED_NEWVALUE_PARAM, valid);
+	}
+
 	public void hasAtMostOneSpecificParameter(ExecutableElement executableElement, String qualifiedName, IsValid valid) {
 		hasAtMostOneSpecificParameter(executableElement, Arrays.asList(qualifiedName), valid);
 	}
@@ -275,4 +291,5 @@ public class ValidatorParameterHelper {
 			}
 		}
 	}
+
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorParameterHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorParameterHelper.java
@@ -98,6 +98,10 @@ public class ValidatorParameterHelper {
 		zeroOrOneSpecificParameter(executableElement, CanonicalNameConstants.BUNDLE, valid);
 	}
 
+	public void zeroOrOnePreferenceParameter(ExecutableElement executableElement, IsValid valid) {
+		zeroOrOneSpecificParameter(executableElement, CanonicalNameConstants.PREFERENCE, valid);
+	}
+
 	public void hasOneOrTwoParametersAndFirstIsBoolean(ExecutableElement executableElement, IsValid valid) {
 		List<? extends VariableElement> parameters = executableElement.getParameters();
 

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EActivityHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EActivityHolder.java
@@ -53,6 +53,7 @@ import com.sun.codemodel.JClassAlreadyExistsException;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JExpr;
 import com.sun.codemodel.JExpression;
+import com.sun.codemodel.JFieldRef;
 import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JInvocation;
 import com.sun.codemodel.JMethod;
@@ -75,6 +76,7 @@ public class EActivityHolder extends EComponentWithViewSupportHolder implements 
 	private OnActivityResultHolder onActivityResultHolder;
 	private ReceiverRegistrationHolder<EActivityHolder> receiverRegistrationHolder;
 	private RoboGuiceHolder roboGuiceHolder;
+	private PreferencesHolder preferencesHolder;
 	private JMethod injectExtrasMethod;
 	private JBlock injectExtrasBlock;
 	private JVar injectExtras;
@@ -102,6 +104,7 @@ public class EActivityHolder extends EComponentWithViewSupportHolder implements 
 		instanceStateHolder = new InstanceStateHolder(this);
 		onActivityResultHolder = new OnActivityResultHolder(this);
 		receiverRegistrationHolder = new ReceiverRegistrationHolder<EActivityHolder>(this);
+		preferencesHolder = new PreferencesHolder(this);
 		setSetContentView();
 		intentBuilder = new ActivityIntentBuilder(this, androidManifest);
 		intentBuilder.build();
@@ -777,4 +780,20 @@ public class EActivityHolder extends EComponentWithViewSupportHolder implements 
 	public JBlock getPreferenceScreenInitializationBlock() {
 		return getInitBody();
 	}
+
+	@Override
+	public JBlock getAddPreferencesFromResourceBlock() {
+		return preferencesHolder.getAddPreferencesFromResourceBlock();
+	}
+
+	@Override
+	public void assignFindPreferenceByKey(JFieldRef idRef, JClass preferenceClass, JFieldRef fieldRef) {
+		preferencesHolder.assignFindPreferenceByKey(idRef, preferenceClass, fieldRef);
+	}
+
+	@Override
+	public FoundPreferenceHolder getFoundPreferenceHolder(JFieldRef idRef, JClass preferenceClass) {
+		return preferencesHolder.getFoundPreferenceHolder(idRef, preferenceClass);
+	}
+
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EActivityHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EActivityHolder.java
@@ -61,7 +61,7 @@ import com.sun.codemodel.JMod;
 import com.sun.codemodel.JType;
 import com.sun.codemodel.JVar;
 
-public class EActivityHolder extends EComponentWithViewSupportHolder implements HasIntentBuilder, HasExtras, HasInstanceState, HasOptionsMenu, HasOnActivityResult, HasReceiverRegistration, HasPreferences {
+public class EActivityHolder extends EComponentWithViewSupportHolder implements HasIntentBuilder, HasExtras, HasInstanceState, HasOptionsMenu, HasOnActivityResult, HasReceiverRegistration, HasPreferenceHeaders {
 
 	private static final String ON_CONTENT_CHANGED_JAVADOC = "We cannot simply copy the " + "code from RoboActivity, because that can cause classpath issues. " + "For further details see issue #1116.";
 
@@ -76,7 +76,7 @@ public class EActivityHolder extends EComponentWithViewSupportHolder implements 
 	private OnActivityResultHolder onActivityResultHolder;
 	private ReceiverRegistrationHolder<EActivityHolder> receiverRegistrationHolder;
 	private RoboGuiceHolder roboGuiceHolder;
-	private PreferencesHolder preferencesHolder;
+	private PreferenceActivityHolder preferencesHolder;
 	private JMethod injectExtrasMethod;
 	private JBlock injectExtrasBlock;
 	private JVar injectExtras;
@@ -104,7 +104,7 @@ public class EActivityHolder extends EComponentWithViewSupportHolder implements 
 		instanceStateHolder = new InstanceStateHolder(this);
 		onActivityResultHolder = new OnActivityResultHolder(this);
 		receiverRegistrationHolder = new ReceiverRegistrationHolder<EActivityHolder>(this);
-		preferencesHolder = new PreferencesHolder(this);
+		preferencesHolder = new PreferenceActivityHolder(this);
 		setSetContentView();
 		intentBuilder = new ActivityIntentBuilder(this, androidManifest);
 		intentBuilder.build();
@@ -794,6 +794,16 @@ public class EActivityHolder extends EComponentWithViewSupportHolder implements 
 	@Override
 	public FoundPreferenceHolder getFoundPreferenceHolder(JFieldRef idRef, JClass preferenceClass) {
 		return preferencesHolder.getFoundPreferenceHolder(idRef, preferenceClass);
+	}
+
+	@Override
+	public JBlock getOnBuildHeadersBlock() {
+		return preferencesHolder.getOnBuildHeadersBlock();
+	}
+
+	@Override
+	public JVar getOnBuildHeadersTargetParam() {
+		return preferencesHolder.getOnBuildHeadersTargetParam();
 	}
 
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EActivityHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EActivityHolder.java
@@ -60,7 +60,7 @@ import com.sun.codemodel.JMod;
 import com.sun.codemodel.JType;
 import com.sun.codemodel.JVar;
 
-public class EActivityHolder extends EComponentWithViewSupportHolder implements HasIntentBuilder, HasExtras, HasInstanceState, HasOptionsMenu, HasOnActivityResult, HasReceiverRegistration {
+public class EActivityHolder extends EComponentWithViewSupportHolder implements HasIntentBuilder, HasExtras, HasInstanceState, HasOptionsMenu, HasOnActivityResult, HasReceiverRegistration, HasPreferences {
 
 	private static final String ON_CONTENT_CHANGED_JAVADOC = "We cannot simply copy the " + "code from RoboActivity, because that can cause classpath issues. " + "For further details see issue #1116.";
 
@@ -773,4 +773,8 @@ public class EActivityHolder extends EComponentWithViewSupportHolder implements 
 		return databaseHelperRef;
 	}
 
+	@Override
+	public JBlock getPreferenceScreenInitializationBlock() {
+		return getInitBody();
+	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EComponentWithViewSupportHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EComponentWithViewSupportHolder.java
@@ -55,7 +55,7 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder {
 	private JBlock onViewChangedBody;
 	private JBlock onViewChangedBodyBeforeFindViews;
 	private JVar onViewChangedHasViewsParam;
-	private Map<String, FoundViewHolder> foundViewsHolders = new HashMap<String, FoundViewHolder>();
+	protected Map<String, FoundHolder> foundHolders = new HashMap<String, FoundHolder>();
 	protected JMethod findNativeFragmentById;
 	protected JMethod findSupportFragmentById;
 	protected JMethod findNativeFragmentByTag;
@@ -108,13 +108,13 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder {
 
 	public void assignFindViewById(JFieldRef idRef, JClass viewClass, JFieldRef fieldRef) {
 		String idRefString = codeModelHelper.getIdStringFromIdFieldRef(idRef);
-		FoundViewHolder foundViewHolder = foundViewsHolders.get(idRefString);
+		FoundViewHolder foundViewHolder = (FoundViewHolder) foundHolders.get(idRefString);
 
 		JBlock block = getOnViewChangedBody();
 		JExpression assignExpression;
 
 		if (foundViewHolder != null) {
-			assignExpression = foundViewHolder.getView(viewClass);
+			assignExpression = foundViewHolder.getOrCastRef(viewClass);
 		} else {
 			assignExpression = findViewById(idRef);
 			if (viewClass != null && viewClass != classes().VIEW) {
@@ -124,7 +124,7 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder {
 					codeModelHelper.addSuppressWarnings(onViewChanged, "unchecked");
 				}
 			}
-			foundViewsHolders.put(idRefString, new FoundViewHolder(this, viewClass, fieldRef, block));
+			foundHolders.put(idRefString, new FoundViewHolder(this, viewClass, fieldRef, block));
 		}
 
 		block.assign(fieldRef, assignExpression);
@@ -132,10 +132,10 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder {
 
 	public FoundViewHolder getFoundViewHolder(JFieldRef idRef, JClass viewClass) {
 		String idRefString = codeModelHelper.getIdStringFromIdFieldRef(idRef);
-		FoundViewHolder foundViewHolder = foundViewsHolders.get(idRefString);
+		FoundViewHolder foundViewHolder = (FoundViewHolder) foundHolders.get(idRefString);
 		if (foundViewHolder == null) {
 			foundViewHolder = createFoundViewAndIfNotNullBlock(idRef, viewClass);
-			foundViewsHolders.put(idRefString, foundViewHolder);
+			foundHolders.put(idRefString, foundViewHolder);
 		}
 		return foundViewHolder;
 	}
@@ -280,4 +280,5 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder {
 
 		return new OnSeekBarChangeListenerHolder(this, onSeekbarChangeListenerClass);
 	}
+
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
@@ -66,6 +66,7 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 	private InstanceStateHolder instanceStateHolder;
 	private OnActivityResultHolder onActivityResultHolder;
 	private ReceiverRegistrationHolder<EFragmentHolder> receiverRegistrationHolder;
+	private PreferencesHolder preferencesHolder;
 	private JBlock onCreateOptionsMenuMethodBody;
 	private JVar onCreateOptionsMenuMenuInflaterVar;
 	private JVar onCreateOptionsMenuMenuParam;
@@ -86,6 +87,7 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 		instanceStateHolder = new InstanceStateHolder(this);
 		onActivityResultHolder = new OnActivityResultHolder(this);
 		receiverRegistrationHolder = new ReceiverRegistrationHolder<EFragmentHolder>(this);
+		preferencesHolder = new PreferencesHolder(this);
 		setOnCreate();
 		setOnViewCreated();
 		setFragmentBuilder();
@@ -564,5 +566,20 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 	@Override
 	public JBlock getPreferenceScreenInitializationBlock() {
 		return getOnCreateAfterSuperBlock();
+	}
+
+	@Override
+	public JBlock getAddPreferencesFromResourceBlock() {
+		return preferencesHolder.getAddPreferencesFromResourceBlock();
+	}
+
+	@Override
+	public void assignFindPreferenceByKey(JFieldRef idRef, JClass preferenceClass, JFieldRef fieldRef) {
+		preferencesHolder.assignFindPreferenceByKey(idRef, preferenceClass, fieldRef);
+	}
+
+	@Override
+	public FoundPreferenceHolder getFoundPreferenceHolder(JFieldRef idRef, JClass preferenceClass) {
+		return preferencesHolder.getFoundPreferenceHolder(idRef, preferenceClass);
 	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
@@ -51,7 +51,7 @@ import com.sun.codemodel.JMod;
 import com.sun.codemodel.JTypeVar;
 import com.sun.codemodel.JVar;
 
-public class EFragmentHolder extends EComponentWithViewSupportHolder implements HasInstanceState, HasOptionsMenu, HasOnActivityResult, HasReceiverRegistration {
+public class EFragmentHolder extends EComponentWithViewSupportHolder implements HasInstanceState, HasOptionsMenu, HasOnActivityResult, HasReceiverRegistration, HasPreferences {
 
 	private JFieldVar contentView;
 	private JBlock setContentViewBlock;
@@ -559,5 +559,10 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 		OrmLiteHelper.injectReleaseInDestroy(databaseHelperRef, this, classes());
 
 		return databaseHelperRef;
+	}
+
+	@Override
+	public JBlock getPreferenceScreenInitializationBlock() {
+		return getOnCreateAfterSuperBlock();
 	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/FoundHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/FoundHolder.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.holder;
+
+import static com.sun.codemodel.JExpr._null;
+import static com.sun.codemodel.JExpr.cast;
+
+import com.sun.codemodel.JBlock;
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JExpression;
+
+public abstract class FoundHolder extends GeneratedClassHolderDecorator<GeneratedClassHolder> {
+
+	private JClass type;
+	private JExpression ref;
+	private JBlock ifNotNullBlock;
+	private boolean ifNotNullCreated = false;
+
+	public FoundHolder(GeneratedClassHolder holder, JClass type, JExpression ref, JBlock block) {
+		super(holder);
+		this.type = type;
+		this.ref = ref;
+		ifNotNullBlock = block;
+	}
+
+	public JExpression getRef() {
+		return ref;
+	}
+
+	public JExpression getOrCastRef(JClass type) {
+		if (this.type.equals(type) || getBaseType().equals(type)) {
+			return ref;
+		} else {
+			return cast(type, ref);
+		}
+	}
+
+	protected abstract JClass getBaseType();
+
+	public JBlock getIfNotNullBlock() {
+		if (!ifNotNullCreated) {
+			ifNotNullBlock = ifNotNullBlock._if(ref.ne(_null()))._then();
+			ifNotNullCreated = true;
+		}
+		return ifNotNullBlock;
+	}
+}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/FoundPreferenceHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/FoundPreferenceHolder.java
@@ -17,15 +17,17 @@ package org.androidannotations.holder;
 
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JClass;
-import com.sun.codemodel.JFieldRef;
+import com.sun.codemodel.JExpression;
 
-public interface HasPreferences extends GeneratedClassHolder {
+public class FoundPreferenceHolder extends FoundHolder {
 
-	JBlock getPreferenceScreenInitializationBlock();
+	public FoundPreferenceHolder(GeneratedClassHolder holder, JClass type, JExpression ref, JBlock block) {
+		super(holder, type, ref, block);
+	}
 
-	JBlock getAddPreferencesFromResourceBlock();
+	@Override
+	protected JClass getBaseType() {
+		return holder.classes().PREFERENCE;
+	}
 
-	void assignFindPreferenceByKey(JFieldRef idRef, JClass preferenceClass, JFieldRef fieldRef);
-
-	FoundPreferenceHolder getFoundPreferenceHolder(JFieldRef idRef, JClass preferenceClass);
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/FoundViewHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/FoundViewHolder.java
@@ -15,44 +15,19 @@
  */
 package org.androidannotations.holder;
 
-import static com.sun.codemodel.JExpr._null;
-import static com.sun.codemodel.JExpr.cast;
-
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JExpression;
 
-public class FoundViewHolder extends GeneratedClassHolderDecorator<GeneratedClassHolder> {
-
-	private JClass viewClass;
-	private JExpression view;
-	private JBlock ifNotNullBlock;
-	private boolean ifNotNullCreated = false;
+public class FoundViewHolder extends FoundHolder {
 
 	public FoundViewHolder(GeneratedClassHolder holder, JClass viewClass, JExpression view, JBlock block) {
-		super(holder);
-		this.viewClass = viewClass;
-		this.view = view;
-		ifNotNullBlock = block;
+		super(holder, viewClass, view, block);
 	}
 
-	public JExpression getView() {
-		return view;
+	@Override
+	protected JClass getBaseType() {
+		return holder.classes().VIEW;
 	}
 
-	public JExpression getView(JClass viewClass) {
-		if (this.viewClass.equals(viewClass) || holder.classes().VIEW.equals(viewClass)) {
-			return view;
-		} else {
-			return cast(viewClass, view);
-		}
-	}
-
-	public JBlock getIfNotNullBlock() {
-		if (!ifNotNullCreated) {
-			ifNotNullBlock = ifNotNullBlock._if(view.ne(_null()))._then();
-			ifNotNullCreated = true;
-		}
-		return ifNotNullBlock;
-	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/HasPreferenceHeaders.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/HasPreferenceHeaders.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.holder;
+
+import com.sun.codemodel.JBlock;
+import com.sun.codemodel.JVar;
+
+public interface HasPreferenceHeaders extends HasPreferences {
+
+	JBlock getOnBuildHeadersBlock();
+
+	JVar getOnBuildHeadersTargetParam();
+}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/HasPreferences.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/HasPreferences.java
@@ -13,19 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.androidannotations.rclass;
+package org.androidannotations.holder;
 
-import java.util.Locale;
+import com.sun.codemodel.JBlock;
 
-public interface IRClass {
+public interface HasPreferences extends GeneratedClassHolder {
 
-	public enum Res {
-		LAYOUT, ID, STRING, ARRAY, COLOR, ANIM, BOOL, DIMEN, DRAWABLE, INTEGER, MOVIE, MENU, RAW, XML;
-		public String rName() {
-			return toString().toLowerCase(Locale.ENGLISH);
-		}
-	}
-
-	IRInnerClass get(Res res);
-
+	JBlock getPreferenceScreenInitializationBlock();
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/PreferenceActivityHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/PreferenceActivityHolder.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.holder;
+
+import static com.sun.codemodel.JMod.PUBLIC;
+import android.preference.PreferenceActivity.Header;
+
+import com.sun.codemodel.JBlock;
+import com.sun.codemodel.JMethod;
+import com.sun.codemodel.JVar;
+
+public class PreferenceActivityHolder extends PreferencesHolder implements HasPreferenceHeaders {
+
+	private JBlock onBuildHeadersBlock;
+
+	private JVar onBuildHeadersTargetParam;
+
+	public PreferenceActivityHolder(EComponentWithViewSupportHolder holder) {
+		super(holder);
+	}
+
+	@Override
+	public JBlock getOnBuildHeadersBlock() {
+		if (onBuildHeadersBlock == null) {
+			setOnBuildHeadersBlock();
+		}
+		return onBuildHeadersBlock;
+	}
+
+	@Override
+	public JVar getOnBuildHeadersTargetParam() {
+		if (onBuildHeadersTargetParam == null) {
+			setOnBuildHeadersBlock();
+		}
+		return onBuildHeadersTargetParam;
+	}
+
+	private void setOnBuildHeadersBlock() {
+		JMethod method = getGeneratedClass().method(PUBLIC, codeModel().VOID, "onBuildHeaders");
+		method.annotate(Override.class);
+		onBuildHeadersBlock = method.body();
+		onBuildHeadersTargetParam = method.param(classes().LIST.narrow(Header.class), "target");
+	}
+
+}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/PreferencesHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/PreferencesHolder.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.holder;
+
+import static com.sun.codemodel.JExpr._this;
+import static com.sun.codemodel.JExpr.cast;
+import static com.sun.codemodel.JExpr.invoke;
+import static com.sun.codemodel.JMod.PUBLIC;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.TypeElement;
+
+import org.androidannotations.helper.APTCodeModelHelper;
+import org.androidannotations.process.ProcessHolder.Classes;
+
+import com.sun.codemodel.JBlock;
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JExpr;
+import com.sun.codemodel.JExpression;
+import com.sun.codemodel.JFieldRef;
+import com.sun.codemodel.JInvocation;
+import com.sun.codemodel.JMethod;
+import com.sun.codemodel.JVar;
+
+public class PreferencesHolder extends GeneratedClassHolderDecorator<EComponentWithViewSupportHolder> implements HasPreferences {
+
+	private APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
+
+	protected JBlock addPreferencesFromResourceBlock;
+
+	public PreferencesHolder(EComponentWithViewSupportHolder holder) {
+		super(holder);
+	}
+
+	@Override
+	public JDefinedClass getGeneratedClass() {
+		return holder.getGeneratedClass();
+	}
+
+	@Override
+	public TypeElement getAnnotatedElement() {
+		return holder.getAnnotatedElement();
+	}
+
+	@Override
+	public ProcessingEnvironment processingEnvironment() {
+		return holder.processingEnvironment();
+	}
+
+	@Override
+	public Classes classes() {
+		return holder.classes();
+	}
+
+	@Override
+	public JCodeModel codeModel() {
+		return holder.codeModel();
+	}
+
+	@Override
+	public JClass refClass(String fullyQualifiedClassName) {
+		return holder.refClass(fullyQualifiedClassName);
+	}
+
+	@Override
+	public JClass refClass(Class<?> clazz) {
+		return refClass(clazz);
+	}
+
+	@Override
+	public JDefinedClass definedClass(String fullyQualifiedClassName) {
+		return definedClass(fullyQualifiedClassName);
+	}
+
+	@Override
+	public JBlock getAddPreferencesFromResourceBlock() {
+		if (addPreferencesFromResourceBlock == null) {
+			setAddPreferencesFromResourceBlock();
+		}
+		return addPreferencesFromResourceBlock;
+	}
+
+	private void setAddPreferencesFromResourceBlock() {
+		JMethod method = getGeneratedClass().method(PUBLIC, codeModel().VOID, "addPreferencesFromResource");
+		method.annotate(Override.class);
+		JVar preferencesResIdParam = method.param(int.class, "preferencesResId");
+		method.body().invoke(JExpr._super(), "addPreferencesFromResource").arg(preferencesResIdParam);
+		addPreferencesFromResourceBlock = method.body();
+	}
+
+	private JInvocation findPreferenceByKey(JFieldRef idRef) {
+		JInvocation getString = invoke(_this(), "getString").arg(idRef);
+		JInvocation findPreferenceByKey = invoke(_this(), "findPreference");
+		return findPreferenceByKey.arg(getString);
+	}
+
+	@Override
+	public void assignFindPreferenceByKey(JFieldRef idRef, JClass preferenceClass, JFieldRef fieldRef) {
+		String idRefString = codeModelHelper.getIdStringFromIdFieldRef(idRef);
+		FoundPreferenceHolder foundViewHolder = (FoundPreferenceHolder) holder.foundHolders.get(idRefString);
+
+		JBlock block = getAddPreferencesFromResourceBlock();
+		JExpression assignExpression;
+
+		if (foundViewHolder != null) {
+			assignExpression = foundViewHolder.getOrCastRef(preferenceClass);
+		} else {
+			assignExpression = findPreferenceByKey(idRef);
+			if (preferenceClass != null && preferenceClass != classes().PREFERENCE) {
+				assignExpression = cast(preferenceClass, assignExpression);
+			}
+			holder.foundHolders.put(idRefString, new FoundPreferenceHolder(this, preferenceClass, fieldRef, block));
+		}
+
+		block.assign(fieldRef, assignExpression);
+	}
+
+	@Override
+	public FoundPreferenceHolder getFoundPreferenceHolder(JFieldRef idRef, JClass preferenceClass) {
+		String idRefString = codeModelHelper.getIdStringFromIdFieldRef(idRef);
+		FoundPreferenceHolder foundPreferenceHolder = (FoundPreferenceHolder) holder.foundHolders.get(idRefString);
+		if (foundPreferenceHolder == null) {
+			foundPreferenceHolder = createFoundPreferenceAndIfNotNullBlock(idRef, preferenceClass);
+			holder.foundHolders.put(idRefString, foundPreferenceHolder);
+		}
+		return foundPreferenceHolder;
+	}
+
+	private FoundPreferenceHolder createFoundPreferenceAndIfNotNullBlock(JFieldRef idRef, JClass preferenceClass) {
+		JExpression findPreferenceExpression = findPreferenceByKey(idRef);
+		JBlock block = getAddPreferencesFromResourceBlock().block();
+
+		if (preferenceClass == null) {
+			preferenceClass = classes().PREFERENCE;
+		} else if (preferenceClass != classes().PREFERENCE) {
+			findPreferenceExpression = cast(preferenceClass, findPreferenceExpression);
+		}
+
+		JVar preference = block.decl(preferenceClass, "preference", findPreferenceExpression);
+		return new FoundPreferenceHolder(this, preferenceClass, preference, block);
+	}
+
+	@Override
+	public JBlock getPreferenceScreenInitializationBlock() {
+		// not used
+		throw new UnsupportedOperationException();
+	}
+}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/process/ProcessHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/process/ProcessHolder.java
@@ -123,6 +123,8 @@ public class ProcessHolder {
 		public final JClass BUILD_VERSION_CODES = refClass(CanonicalNameConstants.BUILD_VERSION_CODES);
 		public final JClass ACTIVITY_COMPAT = refClass(CanonicalNameConstants.ACTIVITY_COMPAT);
 
+		public final JClass PREFERENCE = refClass(CanonicalNameConstants.PREFERENCE);
+
 		/*
 		 * Sherlock
 		 */

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/process/ProcessHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/process/ProcessHolder.java
@@ -125,6 +125,7 @@ public class ProcessHolder {
 
 		public final JClass PREFERENCE = refClass(CanonicalNameConstants.PREFERENCE);
 		public final JClass PREFERENCE_CHANGE_LISTENER = refClass(CanonicalNameConstants.PREFERENCE_CHANGE_LISTENER);
+		public final JClass PREFERENCE_CLICK_LISTENER = refClass(CanonicalNameConstants.PREFERENCE_CLICK_LISTENER);
 
 		/*
 		 * Sherlock

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/process/ProcessHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/process/ProcessHolder.java
@@ -124,6 +124,7 @@ public class ProcessHolder {
 		public final JClass ACTIVITY_COMPAT = refClass(CanonicalNameConstants.ACTIVITY_COMPAT);
 
 		public final JClass PREFERENCE = refClass(CanonicalNameConstants.PREFERENCE);
+		public final JClass PREFERENCE_CHANGE_LISTENER = refClass(CanonicalNameConstants.PREFERENCE_CHANGE_LISTENER);
 
 		/*
 		 * Sherlock

--- a/AndroidAnnotations/functional-test-1-5/res/xml/headers.xml
+++ b/AndroidAnnotations/functional-test-1-5/res/xml/headers.xml
@@ -16,18 +16,10 @@
     the License.
 
 -->
-<resources>
-    
-    <bool name="prefsDefaultBool">true</bool>
-    <string name="prefDefaultString">default pref</string>
-    <integer name="prefDefaultInt">42</integer>
-    <integer name="prefDefaultLong">4200</integer>
-    <integer name="prefDefaultFloat">42</integer>
-    <string name="prefStringKey">stringKey</string>
-    
-    <string name="conventionKey">conventionKey</string>
-    <string name="listPreferenceKey">listPreferenceKey</string>
-    <string name="checkBoxPrefKey">checkBoxPrefKey</string>
-    <string name="switchPrefKey">switchPrefKey</string>
-    
-</resources>
+<preference-headers xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+
+    <header android:fragment="org.androidannotations.test15.preference.PreferenceScreenFragment_" tools:ignore="UnusedAttribute"
+        android:title="@string/hello"
+        />
+
+</preference-headers>

--- a/AndroidAnnotations/functional-test-1-5/res/xml/settings.xml
+++ b/AndroidAnnotations/functional-test-1-5/res/xml/settings.xml
@@ -16,18 +16,18 @@
     the License.
 
 -->
-<resources>
-    
-    <bool name="prefsDefaultBool">true</bool>
-    <string name="prefDefaultString">default pref</string>
-    <integer name="prefDefaultInt">42</integer>
-    <integer name="prefDefaultLong">4200</integer>
-    <integer name="prefDefaultFloat">42</integer>
-    <string name="prefStringKey">stringKey</string>
-    
-    <string name="conventionKey">conventionKey</string>
-    <string name="listPreferenceKey">listPreferenceKey</string>
-    <string name="checkBoxPrefKey">checkBoxPrefKey</string>
-    <string name="switchPrefKey">switchPrefKey</string>
-    
-</resources>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <PreferenceCategory >
+        <ListPreference
+            android:key="@string/listPreferenceKey"/>
+
+        <EditTextPreference
+            android:key="@string/conventionKey" />
+        
+        <CheckBoxPreference android:key="@string/checkBoxPrefKey"/>
+        
+        <SwitchPreference android:key="@string/switchPrefKey"/>
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/preference/PreferenceAnnotationsFragment.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/preference/PreferenceAnnotationsFragment.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test15.preference;
+
+import org.androidannotations.annotations.AfterPreferences;
+import org.androidannotations.annotations.EFragment;
+import org.androidannotations.annotations.PreferenceChange;
+import org.androidannotations.test15.R;
+
+import android.os.Bundle;
+import android.preference.PreferenceFragment;
+
+@EFragment
+public class PreferenceAnnotationsFragment extends PreferenceFragment {
+
+	boolean preferenceWithKeyChanged;
+	boolean afterPreferencesCalled;
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+
+		addPreferencesFromResource(R.xml.settings);
+	}
+
+	@PreferenceChange(R.string.listPreferenceKey)
+	void listPreferenceChanged() {
+		preferenceWithKeyChanged = true;
+	}
+
+	@AfterPreferences
+	void afterPreferences() {
+		afterPreferencesCalled = true;
+	}
+}

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/preference/PreferenceEventsHandledActivity.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/preference/PreferenceEventsHandledActivity.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test15.preference;
+
+import org.androidannotations.annotations.EActivity;
+import org.androidannotations.annotations.PreferenceChange;
+import org.androidannotations.annotations.PreferenceClick;
+import org.androidannotations.test15.R;
+
+import android.os.Bundle;
+import android.preference.Preference;
+import android.preference.PreferenceActivity;
+
+@EActivity
+public class PreferenceEventsHandledActivity extends PreferenceActivity {
+
+	boolean conventionPrefChanged;
+	boolean preferenceWithKeyChanged;
+	Preference preference;
+	Boolean newValue;
+	boolean conventionPrefClicked;
+	boolean preferenceWithKeyClicked;
+
+	@SuppressWarnings("deprecation")
+	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+
+		addPreferencesFromResource(R.xml.settings);
+	}
+
+	@PreferenceChange
+	void conventionKeyPreferenceChanged() {
+		conventionPrefChanged = true;
+	}
+
+	@PreferenceChange(R.string.listPreferenceKey)
+	void listPreferenceChanged() {
+		preferenceWithKeyChanged = true;
+	}
+
+	@PreferenceChange(R.string.checkBoxPrefKey)
+	void checkBoxPreferenceChanged(Preference preference, Boolean newValue) {
+		this.preference = preference;
+		this.newValue = newValue;
+	}
+
+	@PreferenceChange(R.string.switchPrefKey)
+	boolean switchPreferenceChanged() {
+		return false;
+	}
+
+	@PreferenceClick
+	void conventionKeyPreferenceClicked() {
+		conventionPrefClicked = true;
+	}
+
+	@PreferenceClick(R.string.listPreferenceKey)
+	void listPreferenceClicked() {
+		preferenceWithKeyClicked = true;
+	}
+
+	@PreferenceClick(R.string.checkBoxPrefKey)
+	void checkBoxPreferenceClicked(Preference preference) {
+		this.preference = preference;
+	}
+
+	@PreferenceClick(R.string.switchPrefKey)
+	boolean switchPreferenceClicked() {
+		return false;
+	}
+}

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/preference/PreferenceHeadersActivity.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/preference/PreferenceHeadersActivity.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test15.preference;
+
+import java.util.List;
+
+import org.androidannotations.annotations.EActivity;
+import org.androidannotations.annotations.PreferenceHeaders;
+import org.androidannotations.test15.R;
+
+import android.preference.PreferenceActivity;
+
+@PreferenceHeaders(R.xml.headers)
+@EActivity
+public class PreferenceHeadersActivity extends PreferenceActivity {
+
+	List<Header> headers;
+
+	@Override
+	public void onBuildHeaders(List<Header> target) {
+		headers = target;
+		super.onBuildHeaders(target);
+	}
+}

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/preference/PreferenceScreenActivity.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/preference/PreferenceScreenActivity.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test15.preference;
+
+import org.androidannotations.annotations.EActivity;
+import org.androidannotations.annotations.PreferenceScreen;
+import org.androidannotations.test15.R;
+
+import android.preference.PreferenceActivity;
+
+@PreferenceScreen(R.xml.settings)
+@EActivity
+public class PreferenceScreenActivity extends PreferenceActivity {
+
+}

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/preference/PreferenceScreenFragment.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/preference/PreferenceScreenFragment.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test15.preference;
+
+import org.androidannotations.annotations.EFragment;
+import org.androidannotations.annotations.PreferenceScreen;
+import org.androidannotations.test15.R;
+
+import android.preference.PreferenceFragment;
+
+@PreferenceScreen(R.xml.settings)
+@EFragment
+public class PreferenceScreenFragment extends PreferenceFragment {
+
+}

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/preference/PreferencesInjectedActivity.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/preference/PreferencesInjectedActivity.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test15.preference;
+
+import org.androidannotations.annotations.AfterPreferences;
+import org.androidannotations.annotations.EActivity;
+import org.androidannotations.annotations.PreferenceByKey;
+import org.androidannotations.test15.R;
+
+import android.preference.CheckBoxPreference;
+import android.preference.EditTextPreference;
+import android.preference.Preference;
+import android.preference.PreferenceActivity;
+
+@EActivity
+public class PreferencesInjectedActivity extends PreferenceActivity {
+
+	@PreferenceByKey(R.string.listPreferenceKey)
+	Preference pref;
+
+	@PreferenceByKey
+	EditTextPreference conventionKey;
+
+	@PreferenceByKey(R.string.checkBoxPrefKey)
+	CheckBoxPreference checkBoxPreference;
+
+	boolean afterPreferencesCalled;
+
+	@SuppressWarnings("deprecation")
+	@Override
+	protected void onCreate(android.os.Bundle savedInstanceState) {
+		addPreferencesFromResource(R.xml.settings);
+	}
+
+	@AfterPreferences
+	void afterPreferences() {
+		afterPreferencesCalled = true;
+	}
+
+}

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/preference/PreferenceAnnotationsFragmentTestSkipped.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/preference/PreferenceAnnotationsFragmentTestSkipped.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test15.preference;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+import org.androidannotations.test15.R;
+import org.robolectric.util.FragmentTestUtil;
+
+import android.preference.Preference;
+
+// TODO not yet implemented in Robolectric
+// @RunWith(RobolectricTestRunner.class)
+public class PreferenceAnnotationsFragmentTestSkipped {
+
+	private PreferenceAnnotationsFragment_ fragment;
+
+	// @Before
+	public void setUp() {
+		fragment = new PreferenceAnnotationsFragment_();
+		FragmentTestUtil.startFragment(fragment);
+	}
+
+	// @Test
+	public void testPreferenceChangeHandled() {
+		assertThat(fragment.preferenceWithKeyChanged).isFalse();
+
+		Preference preference = fragment.findPreference(fragment.getString(R.string.listPreferenceKey));
+		preference.getOnPreferenceChangeListener().onPreferenceChange(preference, new Object());
+
+		assertThat(fragment.preferenceWithKeyChanged).isTrue();
+	}
+
+	// @Test
+	public void testAfterPreferencesCalled() {
+		assertThat(fragment.afterPreferencesCalled).isTrue();
+	}
+}

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/preference/PreferenceEventsHandledActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/preference/PreferenceEventsHandledActivityTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test15.preference;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.robolectric.Robolectric.setupActivity;
+
+import org.androidannotations.test15.R;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import android.annotation.SuppressLint;
+import android.preference.Preference;
+
+@SuppressWarnings("deprecation")
+@RunWith(RobolectricTestRunner.class)
+public class PreferenceEventsHandledActivityTest {
+
+	private PreferenceEventsHandledActivity_ activity;
+
+	@Before
+	public void setUp() {
+		activity = setupActivity(PreferenceEventsHandledActivity_.class);
+	}
+
+	@Test
+	public void testConventionPreferenceChangeHandled() {
+		assertThat(activity.conventionPrefChanged).isFalse();
+
+		Preference preference = activity.findPreference(activity.getString(R.string.conventionKey));
+		preference.getOnPreferenceChangeListener().onPreferenceChange(preference, new Object());
+
+		assertThat(activity.conventionPrefChanged).isTrue();
+	}
+
+	@Test
+	public void testPreferenceChangeHandled() {
+		assertThat(activity.preferenceWithKeyChanged).isFalse();
+
+		Preference preference = activity.findPreference(activity.getString(R.string.listPreferenceKey));
+		preference.getOnPreferenceChangeListener().onPreferenceChange(preference, new Object());
+
+		assertThat(activity.preferenceWithKeyChanged).isTrue();
+	}
+
+	@SuppressLint("UseValueOf")
+	@Test
+	public void testPreferenceChangeParameterPassed() {
+		Preference preference = activity.findPreference(activity.getString(R.string.checkBoxPrefKey));
+		Boolean newValue = new Boolean(true);
+		preference.getOnPreferenceChangeListener().onPreferenceChange(preference, newValue);
+
+		assertThat(activity.preference).isSameAs(preference);
+		assertThat(activity.newValue).isSameAs(newValue);
+	}
+
+	@Test
+	public void testPreferenceChangeDefaultReturnValue() {
+		Preference preference = activity.findPreference(activity.getString(R.string.listPreferenceKey));
+		boolean result = preference.getOnPreferenceChangeListener().onPreferenceChange(preference, new Object());
+
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	public void testPreferenceChangeCustomReturnValue() {
+		Preference preference = activity.findPreference(activity.getString(R.string.switchPrefKey));
+		boolean result = preference.getOnPreferenceChangeListener().onPreferenceChange(preference, new Object());
+
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void testConventionPreferenceClickHandled() {
+		assertThat(activity.conventionPrefClicked).isFalse();
+
+		Preference preference = activity.findPreference(activity.getString(R.string.conventionKey));
+		preference.getOnPreferenceClickListener().onPreferenceClick(preference);
+
+		assertThat(activity.conventionPrefClicked).isTrue();
+	}
+
+	@Test
+	public void testPreferenceClickHandled() {
+		assertThat(activity.preferenceWithKeyClicked).isFalse();
+
+		Preference preference = activity.findPreference(activity.getString(R.string.listPreferenceKey));
+		preference.getOnPreferenceClickListener().onPreferenceClick(preference);
+
+		assertThat(activity.preferenceWithKeyClicked).isTrue();
+	}
+
+	@Test
+	public void testPreferenceClickParameterPassed() {
+		Preference preference = activity.findPreference(activity.getString(R.string.checkBoxPrefKey));
+		preference.getOnPreferenceClickListener().onPreferenceClick(preference);
+
+		assertThat(activity.preference).isSameAs(preference);
+	}
+
+	@Test
+	public void testPreferenceClickDefaultReturnValue() {
+		Preference preference = activity.findPreference(activity.getString(R.string.listPreferenceKey));
+		boolean result = preference.getOnPreferenceClickListener().onPreferenceClick(preference);
+
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	public void testPreferenceClickCustomReturnValue() {
+		Preference preference = activity.findPreference(activity.getString(R.string.switchPrefKey));
+		boolean result = preference.getOnPreferenceClickListener().onPreferenceClick(preference);
+
+		assertThat(result).isFalse();
+	}
+}

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/preference/PreferenceHeadersActivityTestSkipped.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/preference/PreferenceHeadersActivityTestSkipped.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test15.preference;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.robolectric.Robolectric.setupActivity;
+
+import org.androidannotations.test15.R;
+
+import android.preference.PreferenceActivity.Header;
+
+//@RunWith(RobolectricTestRunner.class)
+public class PreferenceHeadersActivityTestSkipped {
+
+	private PreferenceHeadersActivity_ activity;
+
+	// @Before
+	public void setUp() {
+		activity = setupActivity(PreferenceHeadersActivity_.class);
+	}
+
+	// TODO: preference headers is not yet implemented in Robolectric
+	// @Test
+	public void testPreferenceHeadersInjected() {
+		assertThat(activity.headers).hasSize(1);
+
+		Header header = activity.headers.get(0);
+
+		assertThat(header.titleRes).isEqualTo(R.string.hello);
+	}
+}

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/preference/PreferenceScreenActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/preference/PreferenceScreenActivityTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test15.preference;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.robolectric.Robolectric.setupActivity;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class PreferenceScreenActivityTest {
+
+	private PreferenceScreenActivity_ activity;
+
+	@Before
+	public void setUp() {
+		activity = setupActivity(PreferenceScreenActivity_.class);
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	public void testPreferenceScreenInjected() {
+		assertThat(activity.getPreferenceScreen()).isNotNull();
+	}
+}

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/preference/PreferenceScreenFragmentTestSkipped.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/preference/PreferenceScreenFragmentTestSkipped.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test15.preference;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.robolectric.util.FragmentTestUtil;
+
+// @RunWith(RobolectricTestRunner.class)
+public class PreferenceScreenFragmentTestSkipped {
+
+	private PreferenceScreenFragment_ fragment;
+
+	@Before
+	public void setUp() {
+		fragment = new PreferenceScreenFragment_();
+		FragmentTestUtil.startFragment(fragment);
+	}
+
+	// TODO not yet implemented in Robolectric
+	// @Test
+	public void testPreferenceScreenInjected() {
+		assertThat(fragment.getPreferenceScreen()).isNotNull();
+	}
+}

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/preference/PreferencesInjectedActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/preference/PreferencesInjectedActivityTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test15.preference;
+
+import static org.fest.assertions.api.ANDROID.assertThat;
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.robolectric.Robolectric.setupActivity;
+
+import org.androidannotations.test15.R;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class PreferencesInjectedActivityTest {
+
+	private PreferencesInjectedActivity activity;
+
+	@Before
+	public void setUp() {
+		activity = setupActivity(PreferencesInjectedActivity_.class);
+	}
+
+	@Test
+	public void testPreferenceInjected() {
+		assertThat(activity.pref).hasKey(activity.getString(R.string.listPreferenceKey));
+	}
+
+	@Test
+	public void testConventionPreferenceInjected() {
+		assertThat(activity.conventionKey).hasKey(activity.getString(R.string.conventionKey));
+	}
+
+	@Test
+	public void testPreferenceSubTypeInjected() {
+		assertThat(activity.checkBoxPreference).hasKey(activity.getString(R.string.checkBoxPrefKey));
+	}
+
+	@Test
+	public void testAfterPreferencesCalled() {
+		assertThat(activity.afterPreferencesCalled).isTrue();
+	}
+
+}


### PR DESCRIPTION
This PR is a WIP, and related to #7.

I decided to use resource IDs instead of plain string preference keys in the annotations, since this is the suggested way (if you use a string resource as a key, you can use it both  in java and xml). Also the implementation is easier, since we can rely on existing concepts.

The implementation is basically the same as View injection/listener. Currently there is some code duplication, but i am not sure we should remove that, because it would really obfuscate the intent of the code. But i gladly accept suggestions on that.

@yDelouis, @DayS, @dodgex i would appreciate your feedback.