### PR TITLE
Clean injected View fields in onDestroyView()

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ViewByIdHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ViewByIdHandler.java
@@ -71,6 +71,6 @@ public class ViewByIdHandler extends BaseAnnotationHandler<EComponentWithViewSup
 		JClass viewClass = refClass(typeQualifiedName);
 		JFieldRef fieldRef = ref(fieldName);
 
-		holder.assignFindViewById(idRef, viewClass, fieldRef);
+		holder.processViewById(idRef, viewClass, fieldRef);
 	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EComponentWithViewSupportHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EComponentWithViewSupportHolder.java
@@ -87,6 +87,10 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder {
 		return findViewById;
 	}
 
+	public void processViewById(JFieldRef idRef, JClass viewClass, JFieldRef fieldRef) {
+		assignFindViewById(idRef, viewClass, fieldRef);
+	}
+
 	public void assignFindViewById(JFieldRef idRef, JClass viewClass, JFieldRef fieldRef) {
 		String idRefString = codeModelHelper.getIdStringFromIdFieldRef(idRef);
 		FoundViewHolder foundViewHolder = foundViewsHolders.get(idRefString);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
@@ -65,6 +65,7 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 	private JBlock onPauseBeforeSuperBlock;
 	private JBlock onAttachAfterSuperBlock;
 	private JBlock onDetachBeforeSuperBlock;
+	private JBlock onDestroyViewAfterSuperBlock;
 
 	public EFragmentHolder(ProcessHolder processHolder, TypeElement annotatedElement) throws Exception {
 		super(processHolder, annotatedElement);
@@ -217,11 +218,15 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 
 	public JFieldVar getContentView() {
 		if (contentView == null) {
-			setContentView();
-			setOnCreateView();
-			setOnDestroyView();
+			setContentViewRelatedMethods();
 		}
 		return contentView;
+	}
+
+	private void setContentViewRelatedMethods() {
+		setContentView();
+		setOnCreateView();
+		setOnDestroyView();
 	}
 
 	private void setContentView() {
@@ -249,8 +254,27 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 		JMethod onDestroyView = generatedClass.method(PUBLIC, codeModel().VOID, "onDestroyView");
 		onDestroyView.annotate(Override.class);
 		JBlock body = onDestroyView.body();
-		body.assign(contentView, _null());
 		body.invoke(_super(), onDestroyView);
+		body.assign(contentView, _null());
+		onDestroyViewAfterSuperBlock = body.block();
+	}
+
+	private JBlock getOnDestroyViewAfterSuperBlock() {
+		if (onDestroyViewAfterSuperBlock == null) {
+			setContentViewRelatedMethods();
+		}
+		return onDestroyViewAfterSuperBlock;
+	}
+
+	@Override
+	public void processViewById(JFieldRef idRef, JClass viewClass, JFieldRef fieldRef) {
+		super.processViewById(idRef, viewClass, fieldRef);
+		clearInjectedView(fieldRef);
+	}
+
+	private void clearInjectedView(JFieldRef fieldRef) {
+		JBlock block = getOnDestroyViewAfterSuperBlock();
+		block.assign(fieldRef, _null());
 	}
 
 	private void setOnStart() {


### PR DESCRIPTION
If setRetainInstance(true) has been set on the fragment or
addToBackStack() was applied to FragmentTransaction, the fragment won't be
destroyed and will keep the reference to its parent view in contentView_
and could lead to memory leak.

This change implements onDestroyView() which cleans the reference.
However, the developer is still responsible for cleaning up the injected
views, because otherwise a (badly implemented) background task may get a
NullPointerException.