### PR TITLE
1140 setmessageconverters

### DIFF
--- a/AndroidAnnotations/androidannotations-api/pom.xml
+++ b/AndroidAnnotations/androidannotations-api/pom.xml
@@ -28,7 +28,7 @@
 			<!-- spring-android-rest-template is required to use the Rest API -->
 			<groupId>org.springframework.android</groupId>
 			<artifactId>spring-android-rest-template</artifactId>
-			<version>1.0.0.RELEASE</version>
+			<version>1.0.1.RELEASE</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/AndroidAnnotations/androidannotations/pom.xml
+++ b/AndroidAnnotations/androidannotations/pom.xml
@@ -39,7 +39,7 @@
             <!-- spring-android-rest-template is required to use the Rest API -->
             <groupId>org.springframework.android</groupId>
             <artifactId>spring-android-rest-template</artifactId>
-            <version>1.0.0.RELEASE</version>
+            <version>1.0.1.RELEASE</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/rest/RestHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/rest/RestHandler.java
@@ -97,13 +97,14 @@ public class RestHandler extends BaseGeneratingAnnotationHandler<RestHolder> {
 
 	private void setConverters(Element element, RestHolder holder) {
 		List<DeclaredType> converters = annotationHelper.extractAnnotationClassArrayParameter(element, getTarget(), "converters");
-		JFieldVar restTemplateField = holder.getRestTemplateField();
-		JBlock init = holder.getInit().body();
-		for (DeclaredType converterType : converters) {
-			JInvocation newConverter = codeModelHelper.newBeanOrEBean(holder, converterType, holder.getInitContextParam());
-			init.add(invoke(restTemplateField, "getMessageConverters").invoke("add").arg(newConverter));
+			JFieldVar restTemplateField = holder.getRestTemplateField();
+			JBlock init = holder.getInit().body();
+			init.add(invoke(restTemplateField, "getMessageConverters").invoke("clear"));
+			for (DeclaredType converterType : converters) {
+				JInvocation newConverter = codeModelHelper.newBeanOrEBean(holder, converterType, holder.getInitContextParam());
+				init.add(invoke(restTemplateField, "getMessageConverters").invoke("add").arg(newConverter));
+			}
 		}
-	}
 
 	private void setInterceptors(Element element, RestHolder holder) {
 		List<DeclaredType> interceptors = annotationHelper.extractAnnotationClassArrayParameter(element, getTarget(), "interceptors");

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
@@ -1086,8 +1086,9 @@ public class ValidatorHelper {
 		TypeMirror httpMessageConverterTypeErased = annotationHelper.getTypeUtils().erasure(httpMessageConverterType);
 		List<DeclaredType> converters = annotationHelper.extractAnnotationClassArrayParameter(element, annotationHelper.getTarget(), "converters");
 
-		if (converters == null) {
+		if (converters == null || converters.isEmpty()) {
 			valid.invalidate();
+			annotationHelper.printAnnotationError(element, "At least one converter is required");
 			return;
 		}
 

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/rest/RestConverterTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/rest/RestConverterTest.java
@@ -31,9 +31,9 @@ public class RestConverterTest extends AAProcessorTestHelper {
 	}
 
 	@Test
-	public void client_with_no_converters_compiles() {
+	public void client_with_no_converters_does_not_compile() throws IOException {
 		CompileResult result = compileFiles(ClientWithNoConverters.class);
-		assertCompilationSuccessful(result);
+		assertCompilationErrorOn(ClientWithNoConverters.class, "@Rest", result);
 	}
 
 	@Test

--- a/AndroidAnnotations/functional-test-1-5/pom.xml
+++ b/AndroidAnnotations/functional-test-1-5/pom.xml
@@ -13,7 +13,7 @@
 	<name>functional-test-1-5</name>
 
 	<properties>
-		<spring-android-version>1.0.0.RELEASE</spring-android-version>
+		<spring-android-version>1.0.1.RELEASE</spring-android-version>
 		<jackson-version>1.9.6</jackson-version>
 		<simple-version>2.4.1</simple-version>
 		<android-rome-version>1.0.0-r2</android-rome-version>


### PR DESCRIPTION
This modification should enable forward support for the changes to how HttpMessageConverters are handled in RestTemplate in Spring for Android 2.0.