### PR TITLE
add option to change GENERATION_SUFFIX

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/AndroidAnnotationProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/AndroidAnnotationProcessor.java
@@ -37,6 +37,7 @@ import org.androidannotations.handler.AnnotationHandlers;
 import org.androidannotations.helper.AndroidManifest;
 import org.androidannotations.helper.AndroidManifestFinder;
 import org.androidannotations.helper.ErrorHelper;
+import org.androidannotations.helper.ModelConstants;
 import org.androidannotations.helper.Option;
 import org.androidannotations.helper.OptionsHelper;
 import org.androidannotations.logger.Level;
@@ -68,6 +69,8 @@ public class AndroidAnnotationProcessor extends AbstractProcessor {
 	@Override
 	public synchronized void init(ProcessingEnvironment processingEnv) {
 		super.init(processingEnv);
+
+		ModelConstants.init(processingEnv);
 
 		// Configure Logger
 		LoggerContext loggerContext = LoggerContext.getInstance();

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AppHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AppHandler.java
@@ -16,13 +16,13 @@
 package org.androidannotations.handler;
 
 import static com.sun.codemodel.JExpr.ref;
+import static org.androidannotations.helper.ModelConstants.classSuffix;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 
 import org.androidannotations.annotations.App;
 import org.androidannotations.annotations.EApplication;
-import org.androidannotations.helper.ModelConstants;
 import org.androidannotations.holder.EApplicationHolder;
 import org.androidannotations.holder.EComponentHolder;
 import org.androidannotations.model.AnnotationElements;
@@ -49,7 +49,7 @@ public class AppHandler extends BaseAnnotationHandler<EComponentHolder> {
 	public void process(Element element, EComponentHolder holder) {
 		String fieldName = element.getSimpleName().toString();
 		String applicationQualifiedName = element.asType().toString();
-		JClass applicationClass = refClass(applicationQualifiedName + ModelConstants.GENERATION_SUFFIX);
+		JClass applicationClass = refClass(applicationQualifiedName + classSuffix());
 
 		holder.getInitBody().assign(ref(fieldName), applicationClass.staticInvoke(EApplicationHolder.GET_APPLICATION_INSTANCE));
 	}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/NonConfigurationInstanceHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/NonConfigurationInstanceHandler.java
@@ -18,7 +18,7 @@ package org.androidannotations.handler;
 import static com.sun.codemodel.JExpr._this;
 import static com.sun.codemodel.JExpr.cast;
 import static com.sun.codemodel.JExpr.ref;
-import static org.androidannotations.helper.ModelConstants.GENERATION_SUFFIX;
+import static org.androidannotations.helper.ModelConstants.classSuffix;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
@@ -91,7 +91,7 @@ public class NonConfigurationInstanceHandler extends BaseAnnotationHandler<EActi
 				elementType = element.asType();
 			}
 			String typeQualifiedName = elementType.toString();
-			JClass fieldGeneratedBeanClass = refClass(typeQualifiedName + GENERATION_SUFFIX);
+			JClass fieldGeneratedBeanClass = refClass(typeQualifiedName + classSuffix());
 
 			initIfNonConfigurationNotNullBlock.invoke(cast(fieldGeneratedBeanClass, field), "rebind").arg(_this());
 		}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ReceiverHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ReceiverHandler.java
@@ -20,6 +20,7 @@ import static com.sun.codemodel.JExpr._null;
 import static com.sun.codemodel.JMod.FINAL;
 import static com.sun.codemodel.JMod.PRIVATE;
 import static com.sun.codemodel.JMod.PUBLIC;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import java.util.List;
 
@@ -30,7 +31,6 @@ import javax.lang.model.element.VariableElement;
 
 import org.androidannotations.annotations.Receiver;
 import org.androidannotations.helper.APTCodeModelHelper;
-import org.androidannotations.helper.ModelConstants;
 import org.androidannotations.holder.HasReceiverRegistration;
 import org.androidannotations.holder.ReceiverRegistrationHolder.IntentFilterData;
 import org.androidannotations.model.AnnotationElements;
@@ -82,7 +82,7 @@ public class ReceiverHandler extends BaseAnnotationHandler<HasReceiverRegistrati
 	public void process(Element element, HasReceiverRegistration holder) throws Exception {
 
 		String methodName = element.getSimpleName().toString();
-		String receiverName = methodName + "Receiver" + ModelConstants.GENERATION_SUFFIX;
+		String receiverName = methodName + "Receiver" + generationSuffix();
 
 		Receiver annotation = element.getAnnotation(Receiver.class);
 		String[] actions = annotation.actions();

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/RoboGuiceHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/RoboGuiceHandler.java
@@ -19,6 +19,7 @@ import static com.sun.codemodel.JExpr._new;
 import static com.sun.codemodel.JExpr._super;
 import static com.sun.codemodel.JExpr._this;
 import static com.sun.codemodel.JExpr.invoke;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -96,7 +97,7 @@ public class RoboGuiceHandler extends BaseAnnotationHandler<EActivityHolder> {
 		int i = 1;
 		for (TypeMirror listenterTypeMirror : listenerTypeMirrors) {
 			JClass listenerClass = codeModelHelper.typeMirrorToJClass(listenterTypeMirror, holder);
-			JFieldVar listener = holder.getGeneratedClass().field(JMod.PRIVATE, listenerClass, "listener" + i + "_");
+			JFieldVar listener = holder.getGeneratedClass().field(JMod.PRIVATE, listenerClass, "listener" + i + generationSuffix());
 			codeModelHelper.addSuppressWarnings(listener, "unused");
 			listener.annotate(classes().INJECT);
 			i++;

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/rest/RestServiceHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/rest/RestServiceHandler.java
@@ -15,6 +15,8 @@
  */
 package org.androidannotations.handler.rest;
 
+import static org.androidannotations.helper.ModelConstants.classSuffix;
+
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeMirror;
@@ -22,7 +24,6 @@ import javax.lang.model.type.TypeMirror;
 import org.androidannotations.annotations.rest.Rest;
 import org.androidannotations.annotations.rest.RestService;
 import org.androidannotations.handler.BaseAnnotationHandler;
-import org.androidannotations.helper.ModelConstants;
 import org.androidannotations.holder.EComponentHolder;
 import org.androidannotations.model.AnnotationElements;
 import org.androidannotations.process.IsValid;
@@ -53,7 +54,7 @@ public class RestServiceHandler extends BaseAnnotationHandler<EComponentHolder> 
 		TypeMirror fieldTypeMirror = element.asType();
 		String interfaceName = fieldTypeMirror.toString();
 
-		String generatedClassName = interfaceName + ModelConstants.GENERATION_SUFFIX;
+		String generatedClassName = interfaceName + classSuffix();
 
 		JBlock methodBody = holder.getInitBody();
 

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/APTCodeModelHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/APTCodeModelHelper.java
@@ -17,7 +17,7 @@ package org.androidannotations.helper;
 
 import static com.sun.codemodel.JExpr._new;
 import static com.sun.codemodel.JExpr.lit;
-import static org.androidannotations.helper.ModelConstants.GENERATION_SUFFIX;
+import static org.androidannotations.helper.ModelConstants.classSuffix;
 
 import java.io.StringWriter;
 import java.lang.annotation.Annotation;
@@ -498,7 +498,7 @@ public class APTCodeModelHelper {
 	public JInvocation newBeanOrEBean(GeneratedClassHolder holder, DeclaredType beanType, JVar contextVar) {
 		if (beanType.asElement().getAnnotation(EBean.class) != null) {
 			String typeQualifiedName = beanType.toString();
-			JClass injectedClass = holder.refClass(typeQualifiedName + GENERATION_SUFFIX);
+			JClass injectedClass = holder.refClass(typeQualifiedName + classSuffix());
 			return injectedClass.staticInvoke(EBeanHolder.GET_INSTANCE_METHOD_NAME).arg(contextVar);
 		} else {
 			return _new(holder.refClass(beanType.toString()));

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ActivityIntentBuilder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ActivityIntentBuilder.java
@@ -20,6 +20,7 @@ import static com.sun.codemodel.JExpr.ref;
 import static com.sun.codemodel.JMod.PRIVATE;
 import static com.sun.codemodel.JMod.PUBLIC;
 import static com.sun.codemodel.JMod.STATIC;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import java.util.List;
 
@@ -93,10 +94,10 @@ public class ActivityIntentBuilder extends IntentBuilder {
 
 	private void createAdditionalConstructor() {
 		if (hasFragmentInClasspath()) {
-			fragmentField = addFragmentConstructor(holder.classes().FRAGMENT, "fragment_");
+			fragmentField = addFragmentConstructor(holder.classes().FRAGMENT, "fragment" + generationSuffix());
 		}
 		if (hasFragmentSupportInClasspath()) {
-			fragmentSupportField = addFragmentConstructor(holder.classes().SUPPORT_V4_FRAGMENT, "fragmentSupport_");
+			fragmentSupportField = addFragmentConstructor(holder.classes().SUPPORT_V4_FRAGMENT, "fragmentSupport" + generationSuffix());
 		}
 	}
 

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/AndroidManifestFinder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/AndroidManifestFinder.java
@@ -15,6 +15,8 @@
  */
 package org.androidannotations.helper;
 
+import static org.androidannotations.helper.ModelConstants.classSuffix;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -282,8 +284,8 @@ public class AndroidManifestFinder {
 	private boolean classOrModelClassExists(String className) {
 		Elements elementUtils = processingEnv.getElementUtils();
 
-		if (className.endsWith("_")) {
-			className = className.substring(0, className.length() - 1);
+		if (className.endsWith(classSuffix())) {
+			className = className.substring(0, className.length() - classSuffix().length());
 		}
 		return elementUtils.getTypeElement(className) != null;
 	}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/AnnotationHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/AnnotationHelper.java
@@ -15,8 +15,8 @@
  */
 package org.androidannotations.helper;
 
-import static org.androidannotations.helper.ModelConstants.GENERATION_SUFFIX;
 import static org.androidannotations.helper.ModelConstants.VALID_ENHANCED_COMPONENT_ANNOTATIONS;
+import static org.androidannotations.helper.ModelConstants.classSuffix;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
@@ -92,9 +92,9 @@ public class AnnotationHelper {
 		TypeElement type = typeElementFromQualifiedName(qualifiedName);
 		if (type.getNestingKind() == NestingKind.MEMBER) {
 			String parentGeneratedClass = generatedClassQualifiedNameFromQualifiedName(type.getEnclosingElement().asType().toString());
-			return parentGeneratedClass + "." + type.getSimpleName().toString() + GENERATION_SUFFIX;
+			return parentGeneratedClass + "." + type.getSimpleName().toString() + classSuffix();
 		} else {
-			return qualifiedName + GENERATION_SUFFIX;
+			return qualifiedName + classSuffix();
 		}
 	}
 

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/IntentBuilder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/IntentBuilder.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package org.androidannotations.helper;
 
 import static com.sun.codemodel.JExpr._new;
@@ -24,6 +25,7 @@ import static com.sun.codemodel.JMod.STATIC;
 import static org.androidannotations.helper.CanonicalNameConstants.PARCELABLE;
 import static org.androidannotations.helper.CanonicalNameConstants.SERIALIZABLE;
 import static org.androidannotations.helper.CanonicalNameConstants.STRING;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -77,7 +79,7 @@ public abstract class IntentBuilder {
 	}
 
 	private void createClass() throws JClassAlreadyExistsException {
-		builderClass = holder.getGeneratedClass()._class(PUBLIC | STATIC, "IntentBuilder_");
+		builderClass = holder.getGeneratedClass()._class(PUBLIC | STATIC, "IntentBuilder" + generationSuffix());
 		builderClass._extends(getSuperClass());
 		holder.setIntentBuilderClass(builderClass);
 		contextField = ref("context");

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ModelConstants.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ModelConstants.java
@@ -20,6 +20,9 @@ import static java.util.Arrays.asList;
 import java.lang.annotation.Annotation;
 import java.util.List;
 
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.SourceVersion;
+
 import org.androidannotations.annotations.EActivity;
 import org.androidannotations.annotations.EApplication;
 import org.androidannotations.annotations.EBean;
@@ -35,7 +38,8 @@ import org.androidannotations.annotations.sharedpreferences.SharedPref;
 
 public abstract class ModelConstants {
 
-	public static final String GENERATION_SUFFIX = "_";
+	private static String generationSuffix = "_";
+	private static String classSuffix;
 
 	@SuppressWarnings("unchecked")
 	public static final List<Class<? extends Annotation>> VALID_ENHANCED_VIEW_SUPPORT_ANNOTATIONS = asList(EActivity.class, EViewGroup.class, EView.class, EBean.class, EFragment.class);
@@ -49,4 +53,24 @@ public abstract class ModelConstants {
 	private ModelConstants() {
 	}
 
+	public static void init(ProcessingEnvironment processingEnv) {
+		OptionsHelper optionsHelper = new OptionsHelper(processingEnv);
+		classSuffix = optionsHelper.getClassSuffix().trim();
+
+		if (classSuffix.isEmpty()) {
+			throw new IllegalArgumentException("'" + classSuffix + "' may not be an emtpy string.");
+		}
+
+		if (!SourceVersion.isName(classSuffix) || classSuffix.contains(".")) {
+			throw new IllegalArgumentException("'" + classSuffix + "' is not a valid Java identifier.");
+		}
+	}
+
+	public static String classSuffix() {
+		return classSuffix;
+	}
+
+	public static String generationSuffix() {
+		return generationSuffix;
+	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/OptionsHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/OptionsHelper.java
@@ -33,7 +33,8 @@ public class OptionsHelper {
 		LOG_FILE("logFile", null), //
 		LOG_LEVEL("logLevel", "DEBUG"), //
 		LOG_APPENDER_CONSOLE("logAppenderConsole", "false"), //
-		LOG_APPENDER_FILE("logAppenderFile", "true");
+		LOG_APPENDER_FILE("logAppenderFile", "true"), //
+		CLASS_SUFFIX("classSuffix", "_");
 
 		private String key;
 		private String defaultValue;
@@ -80,6 +81,10 @@ public class OptionsHelper {
 
 	public String getResourcePackageName() {
 		return getString(Option.RESOURCE_PACKAGE_NAME);
+	}
+
+	public String getClassSuffix() {
+		return getString(Option.CLASS_SUFFIX);
 	}
 
 	public String getLogFile() {

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
@@ -26,10 +26,10 @@ import static org.androidannotations.helper.CanonicalNameConstants.CLIENT_HTTP_R
 import static org.androidannotations.helper.CanonicalNameConstants.HTTP_MESSAGE_CONVERTER;
 import static org.androidannotations.helper.CanonicalNameConstants.INTERNET_PERMISSION;
 import static org.androidannotations.helper.CanonicalNameConstants.WAKELOCK_PERMISSION;
-import static org.androidannotations.helper.ModelConstants.GENERATION_SUFFIX;
 import static org.androidannotations.helper.ModelConstants.VALID_ANDROID_ANNOTATIONS;
 import static org.androidannotations.helper.ModelConstants.VALID_ENHANCED_COMPONENT_ANNOTATIONS;
 import static org.androidannotations.helper.ModelConstants.VALID_ENHANCED_VIEW_SUPPORT_ANNOTATIONS;
+import static org.androidannotations.helper.ModelConstants.classSuffix;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -619,7 +619,7 @@ public class ValidatorHelper {
 			TypeElement typeElement = (TypeElement) element;
 
 			String componentQualifiedName = typeElement.getQualifiedName().toString();
-			String generatedComponentQualifiedName = componentQualifiedName + ModelConstants.GENERATION_SUFFIX;
+			String generatedComponentQualifiedName = componentQualifiedName + classSuffix();
 
 			if (!typeElement.getModifiers().contains(Modifier.ABSTRACT) && !applicationClassName.equals(generatedComponentQualifiedName)) {
 				if (applicationClassName.equals(componentQualifiedName)) {
@@ -647,9 +647,9 @@ public class ValidatorHelper {
 			String elementTypeName = type.toString();
 
 			boolean sharedPrefValidatedInRound = false;
-			if (elementTypeName.endsWith(GENERATION_SUFFIX)) {
-				String prefTypeName = elementTypeName.substring(0, elementTypeName.length() - GENERATION_SUFFIX.length());
-				prefTypeName = prefTypeName.replace("_.", ".");
+			if (elementTypeName.endsWith(classSuffix())) {
+				String prefTypeName = elementTypeName.substring(0, elementTypeName.length() - classSuffix().length());
+				prefTypeName = prefTypeName.replace(classSuffix() + ".", ".");
 
 				Set<? extends Element> sharedPrefElements = validatedElements.getRootAnnotatedElements(SharedPref.class.getName());
 
@@ -1112,12 +1112,12 @@ public class ValidatorHelper {
 		}
 
 		String componentQualifiedName = typeElement.getQualifiedName().toString();
-		String generatedComponentQualifiedName = componentQualifiedName + ModelConstants.GENERATION_SUFFIX;
+		String generatedComponentQualifiedName = componentQualifiedName + classSuffix();
 
 		List<String> componentQualifiedNames = androidManifest.getComponentQualifiedNames();
 		if (!componentQualifiedNames.contains(generatedComponentQualifiedName)) {
 			String simpleName = typeElement.getSimpleName().toString();
-			String generatedSimpleName = simpleName + ModelConstants.GENERATION_SUFFIX;
+			String generatedSimpleName = simpleName + classSuffix();
 			if (componentQualifiedNames.contains(componentQualifiedName)) {
 				valid.invalidate();
 				annotationHelper.printAnnotationError(element, "The AndroidManifest.xml file contains the original component, and not the AndroidAnnotations generated component. Please register " + generatedSimpleName + " instead of " + simpleName);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ViewNotifierHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ViewNotifierHelper.java
@@ -20,6 +20,7 @@ import static com.sun.codemodel.JExpr._null;
 import static com.sun.codemodel.JExpr._this;
 import static com.sun.codemodel.JMod.FINAL;
 import static com.sun.codemodel.JMod.PRIVATE;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import org.androidannotations.api.view.HasViews;
 import org.androidannotations.api.view.OnViewChangedNotifier;
@@ -47,7 +48,7 @@ public class ViewNotifierHelper {
 	public JVar replacePreviousNotifier(JBlock block) {
 		JClass notifierClass = holder.refClass(OnViewChangedNotifier.class);
 		if (notifier == null) {
-			notifier = holder.getGeneratedClass().field(PRIVATE | FINAL, notifierClass, "onViewChangedNotifier_", _new(notifierClass));
+			notifier = holder.getGeneratedClass().field(PRIVATE | FINAL, notifierClass, "onViewChangedNotifier" + generationSuffix(), _new(notifierClass));
 			holder.getGeneratedClass()._implements(HasViews.class);
 		}
 		return block.decl(notifierClass, "previousNotifier", notifierClass.staticInvoke("replaceNotifier").arg(notifier));

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/BaseGeneratedClassHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/BaseGeneratedClassHolder.java
@@ -18,7 +18,7 @@ package org.androidannotations.holder;
 import static com.sun.codemodel.JMod.FINAL;
 import static com.sun.codemodel.JMod.PUBLIC;
 import static com.sun.codemodel.JMod.STATIC;
-import static org.androidannotations.helper.ModelConstants.GENERATION_SUFFIX;
+import static org.androidannotations.helper.ModelConstants.classSuffix;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
@@ -55,10 +55,10 @@ public abstract class BaseGeneratedClassHolder implements GeneratedClassHolder {
 		if (annotatedElement.getNestingKind().isNested()) {
 			Element enclosingElement = annotatedElement.getEnclosingElement();
 			GeneratedClassHolder enclosingHolder = processHolder.getGeneratedClassHolder(enclosingElement);
-			String generatedBeanSimpleName = annotatedElement.getSimpleName().toString() + GENERATION_SUFFIX;
+			String generatedBeanSimpleName = annotatedElement.getSimpleName().toString() + classSuffix();
 			generatedClass = enclosingHolder.getGeneratedClass()._class(PUBLIC | FINAL | STATIC, generatedBeanSimpleName, ClassType.CLASS);
 		} else {
-			String generatedClassQualifiedName = annotatedComponentQualifiedName + GENERATION_SUFFIX;
+			String generatedClassQualifiedName = annotatedComponentQualifiedName + classSuffix();
 			generatedClass = codeModel()._class(PUBLIC | FINAL, generatedClassQualifiedName, ClassType.CLASS);
 		}
 		for (TypeParameterElement typeParam : annotatedElement.getTypeParameters()) {
@@ -68,7 +68,7 @@ public abstract class BaseGeneratedClassHolder implements GeneratedClassHolder {
 		setExtends();
 		codeModelHelper.addNonAAAnotations(generatedClass, annotatedElement.getAnnotationMirrors(), this);
 	}
-	
+
 	public JClass getAnnotatedClass() {
 		return annotatedClass;
 	}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EActivityHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EActivityHolder.java
@@ -23,7 +23,7 @@ import static com.sun.codemodel.JExpr.cast;
 import static com.sun.codemodel.JExpr.invoke;
 import static com.sun.codemodel.JMod.PRIVATE;
 import static com.sun.codemodel.JMod.PUBLIC;
-import static org.androidannotations.helper.ModelConstants.GENERATION_SUFFIX;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -118,7 +118,7 @@ public class EActivityHolder extends EComponentWithViewSupportHolder implements 
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, codeModel().VOID, "init_");
+		init = generatedClass.method(PRIVATE, codeModel().VOID, "init" + generationSuffix());
 		JClass bundleClass = classes().BUNDLE;
 		initSavedInstanceParam = init.param(bundleClass, "savedInstanceState");
 		getOnCreate();
@@ -443,21 +443,21 @@ public class EActivityHolder extends EComponentWithViewSupportHolder implements 
 		JClass keyWildCard = classes().KEY.narrow(codeModel().wildcard());
 		JClass scopedHashMap = classes().HASH_MAP.narrow(keyWildCard, classes().OBJECT);
 
-		getRoboGuiceHolder().scopedObjects = getGeneratedClass().field(JMod.PROTECTED, scopedHashMap, "scopedObjects" + GENERATION_SUFFIX);
+		getRoboGuiceHolder().scopedObjects = getGeneratedClass().field(JMod.PROTECTED, scopedHashMap, "scopedObjects" + generationSuffix());
 		getRoboGuiceHolder().scopedObjects.assign(JExpr._new(scopedHashMap));
 	}
 
 	protected void setEventManagerField() {
-		getRoboGuiceHolder().eventManager = generatedClass.field(JMod.PROTECTED, classes().EVENT_MANAGER, "eventManager" + GENERATION_SUFFIX);
+		getRoboGuiceHolder().eventManager = generatedClass.field(JMod.PROTECTED, classes().EVENT_MANAGER, "eventManager" + generationSuffix());
 	}
 
 	protected void setContentViewListenerField() {
-		getRoboGuiceHolder().contentViewListenerField = generatedClass.field(JMod.NONE, classes().CONTENT_VIEW_LISTENER, "ignored" + GENERATION_SUFFIX);
+		getRoboGuiceHolder().contentViewListenerField = generatedClass.field(JMod.NONE, classes().CONTENT_VIEW_LISTENER, "ignored" + generationSuffix());
 		getRoboGuiceHolder().contentViewListenerField.annotate(classes().INJECT);
 	}
 
 	protected void setScopeField() {
-		getRoboGuiceHolder().scope = getGeneratedClass().field(JMod.PRIVATE, classes().CONTEXT_SCOPE, "scope_");
+		getRoboGuiceHolder().scope = getGeneratedClass().field(JMod.PRIVATE, classes().CONTEXT_SCOPE, "scope" + generationSuffix());
 	}
 
 	// CHECKSTYLE:ON
@@ -487,7 +487,7 @@ public class EActivityHolder extends EComponentWithViewSupportHolder implements 
 	}
 
 	private void setInjectExtras() {
-		injectExtrasMethod = generatedClass.method(PRIVATE, codeModel().VOID, "injectExtras_");
+		injectExtrasMethod = generatedClass.method(PRIVATE, codeModel().VOID, "injectExtras" + generationSuffix());
 		JBlock injectExtrasBody = injectExtrasMethod.body();
 		injectExtras = injectExtrasBody.decl(classes().BUNDLE, "extras_", invoke("getIntent").invoke("getExtras"));
 		injectExtrasBlock = injectExtrasBody._if(injectExtras.ne(_null()))._then();

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EApplicationHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EApplicationHolder.java
@@ -20,6 +20,7 @@ import static com.sun.codemodel.JExpr._this;
 import static com.sun.codemodel.JMod.PRIVATE;
 import static com.sun.codemodel.JMod.PUBLIC;
 import static com.sun.codemodel.JMod.STATIC;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import javax.lang.model.element.TypeElement;
 
@@ -47,7 +48,7 @@ public class EApplicationHolder extends EComponentHolder {
 	private void createSingleton() {
 		JClass annotatedComponent = generatedClass._extends();
 
-		staticInstanceField = generatedClass.field(PRIVATE | STATIC, annotatedComponent, "INSTANCE_");
+		staticInstanceField = generatedClass.field(PRIVATE | STATIC, annotatedComponent, "INSTANCE" + generationSuffix());
 		// Static singleton getter and setter
 		JMethod getInstance = generatedClass.method(PUBLIC | STATIC, annotatedComponent, GET_APPLICATION_INSTANCE);
 		getInstance.body()._return(staticInstanceField);
@@ -74,6 +75,6 @@ public class EApplicationHolder extends EComponentHolder {
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, codeModel().VOID, "init_");
+		init = generatedClass.method(PRIVATE, codeModel().VOID, "init" + generationSuffix());
 	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EBeanHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EBeanHolder.java
@@ -20,7 +20,7 @@ import static com.sun.codemodel.JExpr._null;
 import static com.sun.codemodel.JMod.PRIVATE;
 import static com.sun.codemodel.JMod.PUBLIC;
 import static com.sun.codemodel.JMod.STATIC;
-import static org.androidannotations.helper.ModelConstants.GENERATION_SUFFIX;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import java.util.List;
 
@@ -37,7 +37,7 @@ import com.sun.codemodel.JVar;
 
 public class EBeanHolder extends EComponentWithViewSupportHolder {
 
-	public static final String GET_INSTANCE_METHOD_NAME = "getInstance" + GENERATION_SUFFIX;
+	public static final String GET_INSTANCE_METHOD_NAME = "getInstance" + generationSuffix();
 
 	private JFieldVar contextField;
 	private JMethod constructor;
@@ -61,7 +61,7 @@ public class EBeanHolder extends EComponentWithViewSupportHolder {
 
 	public JFieldVar getContextField() {
 		if (contextField == null) {
-			contextField = generatedClass.field(PRIVATE, classes().CONTEXT, "context_");
+			contextField = generatedClass.field(PRIVATE, classes().CONTEXT, "context" + generationSuffix());
 		}
 		return contextField;
 	}
@@ -73,7 +73,7 @@ public class EBeanHolder extends EComponentWithViewSupportHolder {
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, processHolder.codeModel().VOID, "init_");
+		init = generatedClass.method(PRIVATE, processHolder.codeModel().VOID, "init" + generationSuffix());
 	}
 
 	public void invokeInitInConstructor() {
@@ -94,7 +94,7 @@ public class EBeanHolder extends EComponentWithViewSupportHolder {
 		 */
 		if (hasSingletonScope) {
 
-			JFieldVar instanceField = generatedClass.field(PRIVATE | STATIC, generatedClass, "instance_");
+			JFieldVar instanceField = generatedClass.field(PRIVATE | STATIC, generatedClass, "instance" + generationSuffix());
 
 			JBlock creationBlock = factoryMethodBody //
 					._if(instanceField.eq(_null())) //

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EComponentHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EComponentHolder.java
@@ -17,6 +17,7 @@ package org.androidannotations.holder;
 
 import static com.sun.codemodel.JExpr.cast;
 import static com.sun.codemodel.JMod.PRIVATE;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,7 +26,6 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 
 import org.androidannotations.helper.CaseHelper;
-import org.androidannotations.helper.ModelConstants;
 import org.androidannotations.process.ProcessHolder;
 
 import com.sun.codemodel.JBlock;
@@ -84,7 +84,7 @@ public abstract class EComponentHolder extends BaseGeneratedClassHolder {
 	}
 
 	private void setResourcesRef() {
-		resourcesRef = getInitBody().decl(classes().RESOURCES, "resources_", getContextRef().invoke("getResources"));
+		resourcesRef = getInitBody().decl(classes().RESOURCES, "resources" + generationSuffix(), getContextRef().invoke("getResources"));
 	}
 
 	public JFieldVar getPowerManagerRef() {
@@ -99,7 +99,7 @@ public abstract class EComponentHolder extends BaseGeneratedClassHolder {
 		JBlock methodBody = getInitBody();
 
 		JFieldRef serviceRef = classes().CONTEXT.staticRef("POWER_SERVICE");
-		powerManagerRef = getGeneratedClass().field(PRIVATE, classes().POWER_MANAGER, "powerManager_");
+		powerManagerRef = getGeneratedClass().field(PRIVATE, classes().POWER_MANAGER, "powerManager" + generationSuffix());
 		methodBody.assign(powerManagerRef, cast(classes().POWER_MANAGER, getContextRef().invoke("getSystemService").arg(serviceRef)));
 	}
 
@@ -113,7 +113,7 @@ public abstract class EComponentHolder extends BaseGeneratedClassHolder {
 
 	protected JFieldVar setDatabaseHelperRef(TypeMirror databaseHelperTypeMirror) {
 		JClass databaseHelperClass = refClass(databaseHelperTypeMirror.toString());
-		String fieldName = CaseHelper.lowerCaseFirst(databaseHelperClass.name()) + ModelConstants.GENERATION_SUFFIX;
+		String fieldName = CaseHelper.lowerCaseFirst(databaseHelperClass.name()) + generationSuffix();
 		JFieldVar databaseHelperRef = generatedClass.field(PRIVATE, databaseHelperClass, fieldName);
 		databaseHelperRefs.put(databaseHelperTypeMirror, databaseHelperRef);
 
@@ -135,6 +135,6 @@ public abstract class EComponentHolder extends BaseGeneratedClassHolder {
 		JClass handlerClass = classes().HANDLER;
 		JClass looperClass = classes().LOOPER;
 		JInvocation arg = JExpr._new(handlerClass).arg(looperClass.staticInvoke(METHOD_MAIN_LOOPER));
-		handler = generatedClass.field(JMod.PRIVATE, handlerClass, "handler_", arg);
+		handler = generatedClass.field(JMod.PRIVATE, handlerClass, "handler" + generationSuffix(), arg);
 	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
@@ -23,6 +23,7 @@ import static com.sun.codemodel.JExpr.ref;
 import static com.sun.codemodel.JMod.PRIVATE;
 import static com.sun.codemodel.JMod.PUBLIC;
 import static com.sun.codemodel.JMod.STATIC;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -134,7 +135,7 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 	}
 
 	private void setFragmentBuilder() throws JClassAlreadyExistsException {
-		fragmentBuilderClass = generatedClass._class(PUBLIC | STATIC, "FragmentBuilder_");
+		fragmentBuilderClass = generatedClass._class(PUBLIC | STATIC, "FragmentBuilder" + generationSuffix());
 
 		narrowBuilderClass = narrow(fragmentBuilderClass);
 
@@ -227,7 +228,7 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, codeModel().VOID, "init_");
+		init = generatedClass.method(PRIVATE, codeModel().VOID, "init" + generationSuffix());
 		init.param(classes().BUNDLE, "savedInstanceState");
 	}
 
@@ -241,7 +242,7 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 	}
 
 	private void setContentView() {
-		contentView = generatedClass.field(PRIVATE, classes().VIEW, "contentView_");
+		contentView = generatedClass.field(PRIVATE, classes().VIEW, "contentView" + generationSuffix());
 	}
 
 	private void setOnCreateView() {
@@ -382,7 +383,7 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 	}
 
 	private void setInjectArgs() {
-		injectArgsMethod = generatedClass.method(PRIVATE, codeModel().VOID, "injectFragmentArguments_");
+		injectArgsMethod = generatedClass.method(PRIVATE, codeModel().VOID, "injectFragmentArguments" + generationSuffix());
 		JBlock injectExtrasBody = injectArgsMethod.body();
 		injectBundleArgs = injectExtrasBody.decl(classes().BUNDLE, "args_", invoke("getArguments"));
 		injectArgsBlock = injectExtrasBody._if(injectBundleArgs.ne(_null()))._then();

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EProviderHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EProviderHolder.java
@@ -19,6 +19,7 @@ import static com.sun.codemodel.JExpr._super;
 import static com.sun.codemodel.JExpr.invoke;
 import static com.sun.codemodel.JMod.PRIVATE;
 import static com.sun.codemodel.JMod.PUBLIC;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import javax.lang.model.element.TypeElement;
 
@@ -40,7 +41,7 @@ public class EProviderHolder extends EComponentHolder {
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, codeModel().VOID, "init_");
+		init = generatedClass.method(PRIVATE, codeModel().VOID, "init" + generationSuffix());
 		createOnCreate();
 	}
 

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EReceiverHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EReceiverHolder.java
@@ -17,6 +17,7 @@ package org.androidannotations.holder;
 
 import static com.sun.codemodel.JMod.PRIVATE;
 import static com.sun.codemodel.JMod.PUBLIC;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import javax.lang.model.element.TypeElement;
 
@@ -50,7 +51,7 @@ public class EReceiverHolder extends EComponentHolder {
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, codeModel().VOID, "init_");
+		init = generatedClass.method(PRIVATE, codeModel().VOID, "init" + generationSuffix());
 		contextRef = init.param(classes().CONTEXT, "context");
 		if (onReceiveMethod == null) {
 			createOnReceive();

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EServiceHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EServiceHolder.java
@@ -18,6 +18,7 @@ package org.androidannotations.holder;
 import static com.sun.codemodel.JExpr._this;
 import static com.sun.codemodel.JMod.PRIVATE;
 import static com.sun.codemodel.JMod.PUBLIC;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
@@ -61,7 +62,7 @@ public class EServiceHolder extends EComponentHolder implements HasIntentBuilder
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, codeModel().VOID, "init_");
+		init = generatedClass.method(PRIVATE, codeModel().VOID, "init" + generationSuffix());
 		setOnCreate();
 	}
 

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EViewHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EViewHolder.java
@@ -20,6 +20,7 @@ import static com.sun.codemodel.JMod.PRIVATE;
 import static com.sun.codemodel.JMod.PUBLIC;
 import static com.sun.codemodel.JMod.STATIC;
 import static javax.lang.model.element.ElementKind.CONSTRUCTOR;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +44,7 @@ import com.sun.codemodel.JVar;
 public class EViewHolder extends EComponentWithViewSupportHolder {
 
 	protected static final String ALREADY_INFLATED_COMMENT = "" // +
-			+ "The mAlreadyInflated_ hack is needed because of an Android bug\n" // +
+			+ "The alreadyInflated_ hack is needed because of an Android bug\n" // +
 			+ "which leads to infinite calls of onFinishInflate()\n" //
 			+ "when inflating a layout with a parent and using\n" //
 			+ "the <merge /> tag.";
@@ -110,7 +111,7 @@ public class EViewHolder extends EComponentWithViewSupportHolder {
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, codeModel().VOID, "init_");
+		init = generatedClass.method(PRIVATE, codeModel().VOID, "init" + generationSuffix());
 		viewNotifierHelper.wrapInitWithNotifier();
 	}
 
@@ -136,7 +137,7 @@ public class EViewHolder extends EComponentWithViewSupportHolder {
 	protected void setOnFinishInflate() {
 		onFinishInflate = generatedClass.method(PUBLIC, codeModel().VOID, "onFinishInflate");
 		onFinishInflate.annotate(Override.class);
-		onFinishInflate.javadoc().append(ALREADY_INFLATED_COMMENT);
+		onFinishInflate.javadoc().append(ALREADY_INFLATED_COMMENT.replaceAll("alreadyInflated_", "alreadyInflated" + generationSuffix()));
 
 		JBlock ifNotInflated = onFinishInflate.body()._if(getAlreadyInflated().not())._then();
 		ifNotInflated.assign(getAlreadyInflated(), JExpr.TRUE);
@@ -155,6 +156,6 @@ public class EViewHolder extends EComponentWithViewSupportHolder {
 	}
 
 	private void setAlreadyInflated() {
-		alreadyInflated = generatedClass.field(PRIVATE, JType.parse(codeModel(), "boolean"), "alreadyInflated_", JExpr.FALSE);
+		alreadyInflated = generatedClass.field(PRIVATE, JType.parse(codeModel(), "boolean"), "alreadyInflated" + generationSuffix(), JExpr.FALSE);
 	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/InstanceStateHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/InstanceStateHolder.java
@@ -19,6 +19,7 @@ import static com.sun.codemodel.JExpr._null;
 import static com.sun.codemodel.JExpr.ref;
 import static com.sun.codemodel.JMod.PRIVATE;
 import static com.sun.codemodel.JMod.PUBLIC;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.TypeElement;
@@ -63,7 +64,7 @@ public class InstanceStateHolder extends GeneratedClassHolderDecorator<EComponen
 	private void setSaveStateMethod() {
 		JMethod method = getGeneratedClass().method(PUBLIC, codeModel().VOID, "onSaveInstanceState");
 		method.annotate(Override.class);
-		saveStateBundleParam = method.param(classes().BUNDLE, "bundle_");
+		saveStateBundleParam = method.param(classes().BUNDLE, "bundle" + generationSuffix());
 
 		saveStateMethodBody = method.body();
 
@@ -87,7 +88,7 @@ public class InstanceStateHolder extends GeneratedClassHolderDecorator<EComponen
 	}
 
 	private void setRestoreStateMethod() {
-		restoreStateMethod = getGeneratedClass().method(PRIVATE, codeModel().VOID, "restoreSavedInstanceState_");
+		restoreStateMethod = getGeneratedClass().method(PRIVATE, codeModel().VOID, "restoreSavedInstanceState" + generationSuffix());
 		restoreStateBundleParam = restoreStateMethod.param(classes().BUNDLE, "savedInstanceState");
 		getInit().body().invoke(restoreStateMethod).arg(restoreStateBundleParam);
 

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/ReceiverRegistrationHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/ReceiverRegistrationHolder.java
@@ -18,6 +18,7 @@ package org.androidannotations.holder;
 import static com.sun.codemodel.JExpr._new;
 import static com.sun.codemodel.JMod.FINAL;
 import static com.sun.codemodel.JMod.PRIVATE;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -26,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.androidannotations.annotations.Receiver.RegisterAt;
-import org.androidannotations.helper.ModelConstants;
 import org.androidannotations.process.ProcessHolder;
 
 import com.sun.codemodel.JBlock;
@@ -53,7 +53,7 @@ public class ReceiverRegistrationHolder<T extends EComponentHolder & HasReceiver
 	}
 
 	private JFieldVar createIntentFilterField(IntentFilterData intentFilterData) {
-		String intentFilterName = "intentFilter" + (intentFilterFields.size() + 1) + ModelConstants.GENERATION_SUFFIX;
+		String intentFilterName = "intentFilter" + (intentFilterFields.size() + 1) + generationSuffix();
 		JExpression newIntentFilterExpr = _new(classes().INTENT_FILTER);
 		JFieldVar intentFilterField = getGeneratedClass().field(PRIVATE | FINAL, classes().INTENT_FILTER, intentFilterName, newIntentFilterExpr);
 

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/SharedPrefHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/SharedPrefHolder.java
@@ -18,6 +18,8 @@ package org.androidannotations.holder;
 import static com.sun.codemodel.JMod.FINAL;
 import static com.sun.codemodel.JMod.PUBLIC;
 import static com.sun.codemodel.JMod.STATIC;
+import static org.androidannotations.helper.ModelConstants.classSuffix;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,7 +36,6 @@ import org.androidannotations.api.sharedpreferences.SharedPreferencesHelper;
 import org.androidannotations.api.sharedpreferences.StringPrefEditorField;
 import org.androidannotations.api.sharedpreferences.StringSetPrefEditorField;
 import org.androidannotations.helper.CanonicalNameConstants;
-import org.androidannotations.helper.ModelConstants;
 import org.androidannotations.process.ProcessHolder;
 
 import com.sun.codemodel.JBlock;
@@ -95,7 +96,7 @@ public class SharedPrefHolder extends BaseGeneratedClassHolder {
 
 	private void createEditorClass() throws JClassAlreadyExistsException {
 		String interfaceSimpleName = annotatedElement.getSimpleName().toString();
-		editorClass = generatedClass._class(PUBLIC | STATIC | FINAL, interfaceSimpleName + "Editor" + ModelConstants.GENERATION_SUFFIX);
+		editorClass = generatedClass._class(PUBLIC | STATIC | FINAL, interfaceSimpleName + "Editor" + classSuffix());
 		editorClass._extends(processHolder.refClass(EditorHelper.class).narrow(editorClass));
 
 		createEditorConstructor();
@@ -164,7 +165,7 @@ public class SharedPrefHolder extends BaseGeneratedClassHolder {
 	}
 
 	protected void setContextField() {
-		contextField = generatedClass.field(JMod.PRIVATE, classes().CONTEXT, "context_");
+		contextField = generatedClass.field(JMod.PRIVATE, classes().CONTEXT, "context" + generationSuffix());
 		getConstructor().body().assign(JExpr._this().ref(contextField), getConstructorContextParam());
 	}
 
@@ -176,7 +177,7 @@ public class SharedPrefHolder extends BaseGeneratedClassHolder {
 	}
 
 	protected void setEditorContextField() {
-		editorContextField = editorClass.field(JMod.PRIVATE, classes().CONTEXT, "context_");
+		editorContextField = editorClass.field(JMod.PRIVATE, classes().CONTEXT, "context" + generationSuffix());
 		JVar contextParam = editorConstructor.param(classes().CONTEXT, "context");
 		editorConstructor.body().assign(JExpr._this().ref(editorContextField), contextParam);
 		editMethodEditorInvocation.arg(getContextField());

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/generation/ChangedGenerationSuffixTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/generation/ChangedGenerationSuffixTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.generation;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.androidannotations.AndroidAnnotationProcessor;
+import org.androidannotations.utils.AAProcessorTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ChangedGenerationSuffixTest extends AAProcessorTestHelper {
+
+	@Before
+	public void setUp() {
+		addManifestProcessorParameter(ActivityInManifest.class);
+		addProcessor(AndroidAnnotationProcessor.class);
+		ensureOutputDirectoryIsEmpty();
+	}
+
+	@Test
+	public void generateWithDefaultClassSuffix() throws IOException {
+		CompileResult result = compileFiles(ActivityInManifest.class);
+		File generatedFile = toGeneratedFile(ActivityInManifest.class);
+
+		assertCompilationSuccessful(result);
+
+		assertGeneratedClassMatches(generatedFile, "public final class ActivityInManifest_");
+	}
+
+	@Test
+	public void generateWithChangedClassSuffix() throws IOException {
+		addProcessorParameter("classSuffix", "Impl");
+
+		CompileResult result = compileFiles(ActivityInManifest.class);
+		File generatedFile = toGeneratedFile(ActivityInManifest.class);
+
+		assertCompilationSuccessful(result);
+
+		assertGeneratedClassMatches(generatedFile, "public final class ActivityInManifestImpl");
+	}
+}

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/utils/AAProcessorTestHelper.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/utils/AAProcessorTestHelper.java
@@ -15,9 +15,9 @@
  */
 package org.androidannotations.utils;
 
-import java.io.File;
+import static org.androidannotations.helper.ModelConstants.classSuffix;
 
-import org.androidannotations.helper.ModelConstants;
+import java.io.File;
 
 public class AAProcessorTestHelper extends ProcessorTestHelper {
 
@@ -31,7 +31,7 @@ public class AAProcessorTestHelper extends ProcessorTestHelper {
 	}
 
 	public File toGeneratedFile(Class<?> compiledClass) {
-		File output = new File(OUTPUT_DIRECTORY, toPath(compiledClass.getPackage()) + "/" + compiledClass.getSimpleName() + ModelConstants.GENERATION_SUFFIX + SOURCE_FILE_SUFFIX);
+		File output = new File(OUTPUT_DIRECTORY, toPath(compiledClass.getPackage()) + "/" + compiledClass.getSimpleName() + classSuffix() + SOURCE_FILE_SUFFIX);
 		return output;
 	}
 


### PR DESCRIPTION
see https://github.com/excilys/androidannotations/issues/1209

this allows to set the `generationSuffix` via options. at the moment the same valule is used for all generated stuff (classes, fields, methods) where it before was `_`. But for a first look i already opened the PR.