### PR TITLE
ServiceAction intentbuilder methods are no longer chainable

### DIFF
--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/api/builder/IntentServiceStarter.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/api/builder/IntentServiceStarter.java
@@ -16,25 +16,30 @@
 package org.androidannotations.api.builder;
 
 import android.content.ComponentName;
-import android.content.Context;
 import android.content.Intent;
 
-public abstract class ServiceIntentBuilder<I extends ServiceIntentBuilder<I>> extends IntentBuilder<I> implements IntentServiceStarter {
+/**
+ * Provides methods to start {@link android.app.IntentService IntentService}s.
+ */
+public interface IntentServiceStarter {
 
-	public ServiceIntentBuilder(Context context, Class<?> clazz) {
-		super(context, clazz);
-	}
+	/**
+	 * Starts the {@link android.app.IntentService IntentService} by calling
+	 * {@link android.content.Context#startService(android.content.Intent)
+	 * startService} on the previously given {@link android.content.Context
+	 * Context}.
+	 * 
+	 * @return the result of
+	 *         {@link android.content.Context#startService(android.content.Intent)
+	 *         startService}
+	 */
+	ComponentName start();
 
-	public ServiceIntentBuilder(Context context, Intent intent) {
-		super(context, intent);
-	}
+	/**
+	 * Accessor for the built {@link Intent}.
+	 * 
+	 * @return the created {@link Intent}.
+	 */
+	Intent get();
 
-	@Override
-	public ComponentName start() {
-		return context.startService(intent);
-	}
-
-	public boolean stop() {
-		return context.stopService(intent);
-	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ServiceActionHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ServiceActionHandler.java
@@ -29,6 +29,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 
 import org.androidannotations.annotations.ServiceAction;
+import org.androidannotations.api.builder.IntentServiceStarter;
 import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.AnnotationHelper;
 import org.androidannotations.helper.BundleHelper;
@@ -125,7 +126,7 @@ public class ServiceActionHandler extends BaseAnnotationHandler<EIntentServiceHo
 	}
 
 	private void addActionToIntentBuilder(EIntentServiceHolder holder, ExecutableElement executableElement, String methodName, JFieldVar actionKeyField) {
-		JMethod method = holder.getIntentBuilderClass().method(PUBLIC, holder.getIntentBuilderClass(), methodName);
+		JMethod method = holder.getIntentBuilderClass().method(PUBLIC, holder.refClass(IntentServiceStarter.class), methodName);
 		JBlock body = method.body();
 
 		// setAction


### PR DESCRIPTION
Related to #1326.

This is a **breaking change**, because valid (but discouraged) uses will no longer compile, like this:
```java
MyService._intent(context).actionOne().extra("key", "value").start();
```