### PR TITLE
delete libs directory as an entry in src to deal with the Multiple dex files error.

### DIFF
--- a/examples/HelloWorldEclipse/.classpath
+++ b/examples/HelloWorldEclipse/.classpath
@@ -8,7 +8,6 @@
 	</classpathentry>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
-	<classpathentry kind="src" path="libs"/>
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
 	<classpathentry kind="output" path="bin/classes"/>


### PR DESCRIPTION
The `libs` directory added as entry of src in .classpath will cause `Multiple dex files define` error, such as `Multiple dex files define Lorg/androidannotations/annotations/AfterExtras;`.  
The concrete reason is the Eclipse will copy `jar` file in the `libs` directory to the `bin/classes` directory, such as follows:

	F:\workspace\HelloWorldEclipse\bin>tree /F
	│  androidannotations.log
	│  AndroidManifest.xml
	│  R.txt
	│  resources.ap_
	│
	├─classes
	│  │  androidannotations-api-3.1.jar
	│  │
	│  ├─android
	│  │  └─support
	│  │      └─v7
	│  └─org
	│      └─androidannotations
	├─dexedLibs
	│      android-support-v4-259169c26135dabc8292fb369fe13d18.jar
	│      android-support-v7-appcompat-fe8356d7d51ca5e59edf416a1b47d8dc.jar
	│      androidannotations-api-3.1-4d54da3f520ba51cf94de9910532a000.jar
	│      appcompat_v7-b77d366902bda690e3b92b10d6dba35c.jar
	│
	└─res
	    └─crunch
So, delete the entry.