### PR TITLE
Fix crash in Eclipse when @EBean used on fields

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/BaseGeneratingAnnotationHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/BaseGeneratingAnnotationHandler.java
@@ -17,6 +17,7 @@ package org.androidannotations.handler;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 
 import org.androidannotations.holder.GeneratedClassHolder;
@@ -49,7 +50,15 @@ public abstract class BaseGeneratingAnnotationHandler<T extends GeneratedClassHo
 	}
 
 	private boolean isInnerClass(Element element) {
+		if (!isClassOrInterface(element)) {
+			return false;
+		}
+
 		TypeElement typeElement = (TypeElement) element;
 		return typeElement.getNestingKind().isNested();
+	}
+
+	private boolean isClassOrInterface(Element element) {
+		return element.getKind() == ElementKind.INTERFACE || element.getKind() == ElementKind.CLASS;
 	}
 }


### PR DESCRIPTION
@yDelouis i am not sure this is the good way to solve this. Now errors about constructors are printed on the field... We can avoid this by adding a check and return in every `BaseGeneratingAnnotationHandler` child, but it would be not too clean.

Related to #1346 .