### PR TITLE
Support @FragmentArg on fields with type variable type

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
@@ -1034,47 +1034,20 @@ public class ValidatorHelper {
 	}
 
 	public void canBePutInABundle(Element element, IsValid isValid) {
+		TypeMirror typeMirror = element.asType();
 		String typeString = element.asType().toString();
 
 		if (!isKnownBundleCompatibleType(typeString)) {
 
-			if (element.asType() instanceof DeclaredType) {
-
-				DeclaredType declaredType = (DeclaredType) element.asType();
-				typeString = declaredType.asElement().toString();
-
-			} else if (element.asType() instanceof ArrayType) {
+			if (typeMirror instanceof ArrayType) {
 				ArrayType arrayType = (ArrayType) element.asType();
-				TypeMirror componentType = arrayType.getComponentType();
-
-				if (componentType instanceof DeclaredType) {
-
-					DeclaredType declaredType = (DeclaredType) componentType;
-					typeString = declaredType.asElement().toString();
-
-				} else {
-					typeString = componentType.toString();
-				}
-
-			} else {
-				typeString = element.asType().toString();
+				typeMirror = arrayType.getComponentType();
 			}
 
-			TypeElement elementType = annotationHelper.typeElementFromQualifiedName(typeString);
-
-			if (elementType == null) {
-				elementType = getArrayEnclosingType(typeString);
-
-				if (elementType == null) {
-					annotationHelper.printAnnotationError(element, "Unrecognized type. Please let your attribute be primitive or implement Serializable or Parcelable");
-					isValid.invalidate();
-				}
-			}
-
-			if (elementType != null) {
-				TypeElement parcelableType = annotationHelper.typeElementFromQualifiedName(CanonicalNameConstants.PARCELABLE);
-				TypeElement serializableType = annotationHelper.typeElementFromQualifiedName("java.io.Serializable");
-				if (!annotationHelper.isSubtype(elementType, parcelableType) && !annotationHelper.isSubtype(elementType, serializableType)) {
+			if (typeMirror.getKind() != TypeKind.NONE) {
+				TypeMirror parcelableType = annotationHelper.typeElementFromQualifiedName(CanonicalNameConstants.PARCELABLE).asType();
+				TypeMirror serializableType = annotationHelper.typeElementFromQualifiedName("java.io.Serializable").asType();
+				if (!annotationHelper.isSubtype(typeMirror, parcelableType) && !annotationHelper.isSubtype(typeMirror, serializableType)) {
 					annotationHelper.printAnnotationError(element, "Unrecognized type. Please let your attribute be primitive or implement Serializable or Parcelable");
 					isValid.invalidate();
 				}

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/GenericFragmentArguments.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/GenericFragmentArguments.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test15;
+
+import java.io.Serializable;
+
+import org.androidannotations.annotations.EFragment;
+import org.androidannotations.annotations.FragmentArg;
+
+import android.accounts.Account;
+import android.app.Fragment;
+
+@EFragment
+public class GenericFragmentArguments<S extends Serializable, P extends Account> extends Fragment {
+
+	@FragmentArg
+	S[] serializableArray;
+
+	@FragmentArg
+	P[] parcelableArray;
+
+	@FragmentArg
+	S serializable;
+
+	@FragmentArg
+	P parcelable;
+
+}

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/GenericFragmentArgsTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/GenericFragmentArgsTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test15;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+import java.io.Serializable;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import android.accounts.Account;
+import android.os.Bundle;
+
+@Config(shadows = CustomShadowBundle.class)
+@RunWith(RobolectricTestRunner.class)
+public class GenericFragmentArgsTest {
+
+	private static final Account[] TEST_ARRAY = new Account[] { new Account("Android", "Annotations") };
+
+	@Test
+	public void testParcelableArrayFragmentArgInjected() {
+		Bundle bundle = new Bundle();
+		bundle.putParcelableArray("parcelableArray", TEST_ARRAY);
+
+		GenericFragmentArguments<Serializable, Account> fragment = new GenericFragmentArguments_<Serializable, Account>();
+		fragment.setArguments(bundle);
+
+		assertThat(fragment.parcelableArray).isNull();
+
+		fragment.onCreate(null);
+
+		assertThat(fragment.parcelableArray).isEqualTo(TEST_ARRAY);
+	}
+}


### PR DESCRIPTION
Related to #1444.

The old code has lots of things like this:

```java
DeclaredType declaredType = (DeclaredType) element;
typeString = declaredType.asElement().toString();
elementType = annotationHelper.typeElementFromQualifiedName(typeString);
```

So basically serialize the type to a string, the reload the type from it. It is totally unnecessary in most cases i think, but it is maybe an old workaround that i do not know. All tests pass and my projects are working with the new way. @DayS @yDelouis any thoughts whether the old method was intentional or not?