### PR TITLE
Refactor APTCodeModelHelper usages

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AbstractListenerHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/AbstractListenerHandler.java
@@ -26,7 +26,6 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.AndroidManifest;
 import org.androidannotations.helper.IdAnnotationHelper;
 import org.androidannotations.helper.IdValidatorHelper;
@@ -48,7 +47,6 @@ import com.sun.codemodel.JVar;
 
 public abstract class AbstractListenerHandler<T extends GeneratedClassHolder> extends BaseAnnotationHandler<T> {
 
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 	private IdAnnotationHelper helper;
 	private T holder;
 	private String methodName;

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/BackgroundHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/BackgroundHandler.java
@@ -24,7 +24,6 @@ import javax.lang.model.element.ExecutableElement;
 
 import org.androidannotations.annotations.Background;
 import org.androidannotations.api.BackgroundExecutor;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.holder.EComponentHolder;
 
 import com.sun.codemodel.JBlock;
@@ -39,8 +38,6 @@ import com.sun.codemodel.JTryBlock;
 import com.sun.codemodel.JVar;
 
 public class BackgroundHandler extends AbstractRunnableHandler {
-
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public BackgroundHandler(ProcessingEnvironment processingEnvironment) {
 		super(Background.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/BaseAnnotationHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/BaseAnnotationHandler.java
@@ -19,6 +19,7 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeMirror;
 
+import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.AndroidManifest;
 import org.androidannotations.helper.IdAnnotationHelper;
 import org.androidannotations.helper.IdValidatorHelper;
@@ -42,6 +43,7 @@ public abstract class BaseAnnotationHandler<T extends GeneratedClassHolder> impl
 	protected AndroidManifest androidManifest;
 	protected AnnotationElements validatedModel;
 	protected ProcessHolder processHolder;
+	protected APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public BaseAnnotationHandler(Class<?> targetClass, ProcessingEnvironment processingEnvironment) {
 		this(targetClass.getCanonicalName(), processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ExtraHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ExtraHandler.java
@@ -26,7 +26,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeMirror;
 
 import org.androidannotations.annotations.Extra;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.AnnotationHelper;
 import org.androidannotations.helper.BundleHelper;
 import org.androidannotations.helper.CaseHelper;
@@ -47,7 +46,6 @@ import com.sun.codemodel.JVar;
 public class ExtraHandler extends BaseAnnotationHandler<HasExtras> {
 
 	private final AnnotationHelper annotationHelper;
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public ExtraHandler(ProcessingEnvironment processingEnvironment) {
 		super(Extra.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ExtraParameterHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ExtraParameterHandler.java
@@ -26,7 +26,6 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.VariableElement;
 
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.AnnotationHelper;
 import org.androidannotations.helper.BundleHelper;
 import org.androidannotations.helper.CaseHelper;
@@ -45,7 +44,6 @@ import com.sun.codemodel.JVar;
 public abstract class ExtraParameterHandler extends BaseAnnotationHandler<GeneratedClassHolder> {
 
 	private Class<? extends Annotation> methodAnnotationClass;
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 	private AnnotationHelper annotationHelper;
 
 	public ExtraParameterHandler(Class<? extends Annotation> targetClass, Class<? extends Annotation> methodAnnotationClass, ProcessingEnvironment processingEnvironment) {

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/FragmentArgHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/FragmentArgHandler.java
@@ -26,7 +26,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeMirror;
 
 import org.androidannotations.annotations.FragmentArg;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.AnnotationHelper;
 import org.androidannotations.helper.BundleHelper;
 import org.androidannotations.helper.CaseHelper;
@@ -47,7 +46,6 @@ import com.sun.codemodel.JVar;
 public class FragmentArgHandler extends BaseAnnotationHandler<EFragmentHolder> {
 
 	private final AnnotationHelper annotationHelper;
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public FragmentArgHandler(ProcessingEnvironment processingEnvironment) {
 		super(FragmentArg.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/IgnoredWhenDetachedHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/IgnoredWhenDetachedHandler.java
@@ -23,7 +23,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 
 import org.androidannotations.annotations.IgnoredWhenDetached;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.holder.EFragmentHolder;
 import org.androidannotations.model.AnnotationElements;
 import org.androidannotations.process.IsValid;
@@ -32,8 +31,6 @@ import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JMethod;
 
 public class IgnoredWhenDetachedHandler extends BaseAnnotationHandler<EFragmentHolder> {
-
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public IgnoredWhenDetachedHandler(ProcessingEnvironment processingEnvironment) {
 		super(IgnoredWhenDetached.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/InstanceStateHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/InstanceStateHandler.java
@@ -22,7 +22,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeMirror;
 
 import org.androidannotations.annotations.InstanceState;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.AnnotationHelper;
 import org.androidannotations.helper.BundleHelper;
 import org.androidannotations.holder.HasInstanceState;
@@ -39,7 +38,6 @@ import com.sun.codemodel.JVar;
 
 public class InstanceStateHandler extends BaseAnnotationHandler<HasInstanceState> {
 
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 	private AnnotationHelper annotationHelper;
 
 	public InstanceStateHandler(ProcessingEnvironment processingEnvironment) {

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ItemClickHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ItemClickHandler.java
@@ -28,7 +28,6 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
 import org.androidannotations.annotations.ItemClick;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.holder.EComponentWithViewSupportHolder;
 import org.androidannotations.model.AnnotationElements;
 import org.androidannotations.process.IsValid;
@@ -42,8 +41,6 @@ import com.sun.codemodel.JMod;
 import com.sun.codemodel.JVar;
 
 public class ItemClickHandler extends AbstractViewListenerHandler {
-
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public ItemClickHandler(ProcessingEnvironment processingEnvironment) {
 		super(ItemClick.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ItemLongClickHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ItemLongClickHandler.java
@@ -28,7 +28,6 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
 import org.androidannotations.annotations.ItemLongClick;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.holder.EComponentWithViewSupportHolder;
 import org.androidannotations.model.AnnotationElements;
 import org.androidannotations.process.IsValid;
@@ -43,8 +42,6 @@ import com.sun.codemodel.JMod;
 import com.sun.codemodel.JVar;
 
 public class ItemLongClickHandler extends AbstractViewListenerHandler {
-
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public ItemLongClickHandler(ProcessingEnvironment processingEnvironment) {
 		super(ItemLongClick.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/NonConfigurationInstanceHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/NonConfigurationInstanceHandler.java
@@ -41,7 +41,6 @@ import com.sun.codemodel.JVar;
 
 public class NonConfigurationInstanceHandler extends BaseAnnotationHandler<EActivityHolder> {
 
-	private final APTCodeModelHelper codeModelHelper;
 	private final AnnotationHelper annotationHelper;
 
 	public NonConfigurationInstanceHandler(ProcessingEnvironment processingEnvironment) {

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/OrmLiteDaoHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/OrmLiteDaoHandler.java
@@ -44,7 +44,6 @@ public class OrmLiteDaoHandler extends BaseAnnotationHandler<EComponentHolder> {
 
 	private final OrmLiteHelper ormLiteHelper;
 	private final TargetAnnotationHelper helper;
-	private final APTCodeModelHelper codeModelHelper;
 
 	public OrmLiteDaoHandler(ProcessingEnvironment processingEnvironment) {
 		super(OrmLiteDao.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceChangeHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/PreferenceChangeHandler.java
@@ -25,7 +25,6 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
 import org.androidannotations.annotations.PreferenceChange;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.CanonicalNameConstants;
 import org.androidannotations.holder.HasPreferences;
 import org.androidannotations.model.AnnotationElements;
@@ -42,8 +41,6 @@ import com.sun.codemodel.JType;
 import com.sun.codemodel.JVar;
 
 public class PreferenceChangeHandler extends AbstractPreferenceListenerHandler {
-
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public PreferenceChangeHandler(ProcessingEnvironment processingEnvironment) {
 		super(PreferenceChange.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ProduceHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ProduceHandler.java
@@ -19,7 +19,6 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.CanonicalNameConstants;
 import org.androidannotations.helper.TargetAnnotationHelper;
 import org.androidannotations.holder.EComponentHolder;
@@ -29,7 +28,6 @@ import org.androidannotations.process.IsValid;
 public class ProduceHandler extends BaseAnnotationHandler<EComponentHolder> {
 
 	private final TargetAnnotationHelper annotationHelper;
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public ProduceHandler(ProcessingEnvironment processingEnvironment) {
 		super(CanonicalNameConstants.PRODUCE, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ReceiverActionHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ReceiverActionHandler.java
@@ -30,7 +30,6 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 
 import org.androidannotations.annotations.ReceiverAction;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.CanonicalNameConstants;
 import org.androidannotations.helper.CaseHelper;
 import org.androidannotations.holder.EReceiverHolder;
@@ -47,7 +46,6 @@ import com.sun.codemodel.JVar;
 
 public class ReceiverActionHandler extends BaseAnnotationHandler<EReceiverHolder> {
 
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 	private ExtraHandler extraHandler;
 
 	public ReceiverActionHandler(ProcessingEnvironment processingEnvironment) {

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ReceiverHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ReceiverHandler.java
@@ -30,7 +30,6 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 
 import org.androidannotations.annotations.Receiver;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.CanonicalNameConstants;
 import org.androidannotations.holder.HasReceiverRegistration;
 import org.androidannotations.holder.ReceiverRegistrationHolder.IntentFilterData;
@@ -49,7 +48,6 @@ import com.sun.codemodel.JVar;
 
 public class ReceiverHandler extends BaseAnnotationHandler<HasReceiverRegistration> {
 
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 	private ExtraHandler extraHandler;
 
 	public ReceiverHandler(ProcessingEnvironment processingEnvironment) {

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/RoboGuiceHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/RoboGuiceHandler.java
@@ -34,7 +34,6 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeMirror;
 
 import org.androidannotations.annotations.RoboGuice;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.holder.EActivityHolder;
 import org.androidannotations.holder.RoboGuiceHolder;
 import org.androidannotations.model.AnnotationElements;
@@ -52,8 +51,6 @@ import com.sun.codemodel.JTryBlock;
 import com.sun.codemodel.JVar;
 
 public class RoboGuiceHandler extends BaseAnnotationHandler<EActivityHolder> {
-
-	private APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public RoboGuiceHandler(ProcessingEnvironment processingEnvironment) {
 		super(RoboGuice.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ServiceActionHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ServiceActionHandler.java
@@ -29,7 +29,6 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 
 import org.androidannotations.annotations.ServiceAction;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.AnnotationHelper;
 import org.androidannotations.helper.BundleHelper;
 import org.androidannotations.helper.CaseHelper;
@@ -48,7 +47,6 @@ import com.sun.codemodel.JVar;
 
 public class ServiceActionHandler extends BaseAnnotationHandler<EIntentServiceHolder> {
 
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 	private AnnotationHelper annotationHelper;
 
 	public ServiceActionHandler(ProcessingEnvironment processingEnvironment) {

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/SubscribeHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/SubscribeHandler.java
@@ -19,7 +19,6 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.CanonicalNameConstants;
 import org.androidannotations.helper.TargetAnnotationHelper;
 import org.androidannotations.holder.EComponentHolder;
@@ -29,7 +28,6 @@ import org.androidannotations.process.IsValid;
 public class SubscribeHandler extends BaseAnnotationHandler<EComponentHolder> {
 
 	private final TargetAnnotationHelper annotationHelper;
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public SubscribeHandler(ProcessingEnvironment processingEnvironment) {
 		super(CanonicalNameConstants.SUBSCRIBE, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/SupposeBackgroundHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/SupposeBackgroundHandler.java
@@ -23,7 +23,6 @@ import javax.lang.model.element.ExecutableElement;
 
 import org.androidannotations.annotations.SupposeBackground;
 import org.androidannotations.api.BackgroundExecutor;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.holder.EComponentHolder;
 
 import com.sun.codemodel.JBlock;
@@ -35,8 +34,6 @@ public class SupposeBackgroundHandler extends SupposeThreadHandler {
 
 	private static final String METHOD_CHECK_BG_THREAD = "checkBgThread";
 
-	private final APTCodeModelHelper helper = new APTCodeModelHelper();
-
 	public SupposeBackgroundHandler(ProcessingEnvironment processingEnvironment) {
 		super(SupposeBackground.class, processingEnvironment);
 	}
@@ -45,7 +42,7 @@ public class SupposeBackgroundHandler extends SupposeThreadHandler {
 	public void process(Element element, EComponentHolder holder) throws Exception {
 		ExecutableElement executableElement = (ExecutableElement) element;
 
-		JMethod delegatingMethod = helper.overrideAnnotatedMethod(executableElement, holder);
+		JMethod delegatingMethod = codeModelHelper.overrideAnnotatedMethod(executableElement, holder);
 
 		JClass bgExecutor = refClass(BackgroundExecutor.class);
 

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/SupposeUiThreadHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/SupposeUiThreadHandler.java
@@ -21,7 +21,6 @@ import javax.lang.model.element.ExecutableElement;
 
 import org.androidannotations.annotations.SupposeUiThread;
 import org.androidannotations.api.BackgroundExecutor;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.holder.EComponentHolder;
 
 import com.sun.codemodel.JBlock;
@@ -32,8 +31,6 @@ public class SupposeUiThreadHandler extends SupposeThreadHandler {
 
 	private static final String METHOD_CHECK_UI_THREAD = "checkUiThread";
 
-	private final APTCodeModelHelper helper = new APTCodeModelHelper();
-
 	public SupposeUiThreadHandler(ProcessingEnvironment processingEnvironment) {
 		super(SupposeUiThread.class, processingEnvironment);
 	}
@@ -42,7 +39,7 @@ public class SupposeUiThreadHandler extends SupposeThreadHandler {
 	public void process(Element element, EComponentHolder holder) throws Exception {
 		ExecutableElement executableElement = (ExecutableElement) element;
 
-		JMethod delegatingMethod = helper.overrideAnnotatedMethod(executableElement, holder);
+		JMethod delegatingMethod = codeModelHelper.overrideAnnotatedMethod(executableElement, holder);
 		JBlock body = delegatingMethod.body();
 
 		JClass bgExecutor = refClass(BackgroundExecutor.class);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/TraceHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/TraceHandler.java
@@ -30,7 +30,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 
 import org.androidannotations.annotations.Trace;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.holder.EComponentHolder;
 import org.androidannotations.model.AnnotationElements;
 import org.androidannotations.process.IsValid;
@@ -48,8 +47,6 @@ import com.sun.codemodel.JType;
 import com.sun.codemodel.JVar;
 
 public class TraceHandler extends BaseAnnotationHandler<EComponentHolder> {
-
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public TraceHandler(ProcessingEnvironment processingEnvironment) {
 		super(Trace.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/TransactionalHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/TransactionalHandler.java
@@ -20,7 +20,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 
 import org.androidannotations.annotations.Transactional;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.CanonicalNameConstants;
 import org.androidannotations.holder.EComponentHolder;
 import org.androidannotations.model.AnnotationElements;
@@ -37,8 +36,6 @@ import com.sun.codemodel.JTryBlock;
 import com.sun.codemodel.JVar;
 
 public class TransactionalHandler extends BaseAnnotationHandler<EComponentHolder> {
-
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public TransactionalHandler(ProcessingEnvironment processingEnvironment) {
 		super(Transactional.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/UiThreadHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/UiThreadHandler.java
@@ -24,7 +24,6 @@ import javax.lang.model.element.ExecutableElement;
 
 import org.androidannotations.annotations.UiThread;
 import org.androidannotations.api.UiThreadExecutor;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.holder.EComponentHolder;
 import org.androidannotations.model.AnnotationElements;
 import org.androidannotations.process.IsValid;
@@ -44,8 +43,6 @@ public class UiThreadHandler extends AbstractRunnableHandler {
 	private static final String METHOD_MAIN_LOOPER = "getMainLooper";
 	private static final String METHOD_GET_THREAD = "getThread";
 	private static final String METHOD_RUN_TASK = "runTask";
-
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public UiThreadHandler(ProcessingEnvironment processingEnvironment) {
 		super(UiThread.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ViewByIdHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ViewByIdHandler.java
@@ -38,7 +38,6 @@ import com.sun.codemodel.JFieldRef;
 public class ViewByIdHandler extends BaseAnnotationHandler<EComponentWithViewSupportHolder> {
 
 	private IdAnnotationHelper annotationHelper;
-	private APTCodeModelHelper codeModelHelper;
 
 	public ViewByIdHandler(ProcessingEnvironment processingEnvironment) {
 		super(ViewById.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ViewsByIdHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/ViewsByIdHandler.java
@@ -27,7 +27,6 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
 import org.androidannotations.annotations.ViewsById;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.AndroidManifest;
 import org.androidannotations.helper.CanonicalNameConstants;
 import org.androidannotations.helper.IdAnnotationHelper;
@@ -45,7 +44,6 @@ import com.sun.codemodel.JFieldRef;
 public class ViewsByIdHandler extends BaseAnnotationHandler<EComponentWithViewSupportHolder> {
 
 	private IdAnnotationHelper helper;
-	private APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public ViewsByIdHandler(ProcessingEnvironment processingEnvironment) {
 		super(ViewsById.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/WakeLockHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/WakeLockHandler.java
@@ -22,7 +22,6 @@ import javax.lang.model.element.ExecutableElement;
 import org.androidannotations.annotations.WakeLock;
 import org.androidannotations.annotations.WakeLock.Flag;
 import org.androidannotations.annotations.WakeLock.Level;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.holder.EComponentHolder;
 import org.androidannotations.model.AnnotationElements;
 import org.androidannotations.process.IsValid;
@@ -37,8 +36,6 @@ import com.sun.codemodel.JTryBlock;
 import com.sun.codemodel.JVar;
 
 public class WakeLockHandler extends BaseAnnotationHandler<EComponentHolder> {
-
-	private final APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 
 	public WakeLockHandler(ProcessingEnvironment processingEnvironment) {
 		super(WakeLock.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/rest/RestHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/rest/RestHandler.java
@@ -45,7 +45,6 @@ import com.sun.codemodel.JInvocation;
 public class RestHandler extends BaseGeneratingAnnotationHandler<RestHolder> {
 
 	private final AnnotationHelper annotationHelper;
-	private final APTCodeModelHelper codeModelHelper;
 
 	public RestHandler(ProcessingEnvironment processingEnvironment) {
 		super(Rest.class, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/rest/RestMethodHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/rest/RestMethodHandler.java
@@ -53,7 +53,6 @@ import com.sun.codemodel.JVar;
 public abstract class RestMethodHandler extends BaseAnnotationHandler<RestHolder> {
 
 	protected final RestAnnotationHelper restAnnotationHelper;
-	protected final APTCodeModelHelper codeModelHelper;
 
 	public RestMethodHandler(Class<?> targetClass, ProcessingEnvironment processingEnvironment) {
 		super(targetClass, processingEnvironment);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EComponentWithViewSupportHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EComponentWithViewSupportHolder.java
@@ -33,7 +33,6 @@ import javax.lang.model.type.TypeMirror;
 import org.androidannotations.api.view.HasViews;
 import org.androidannotations.api.view.OnViewChangedListener;
 import org.androidannotations.api.view.OnViewChangedNotifier;
-import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.ViewNotifierHelper;
 import org.androidannotations.process.ProcessHolder;
 
@@ -49,7 +48,6 @@ import com.sun.codemodel.JVar;
 
 public abstract class EComponentWithViewSupportHolder extends EComponentHolder {
 
-	protected APTCodeModelHelper codeModelHelper = new APTCodeModelHelper();
 	protected ViewNotifierHelper viewNotifierHelper;
 	private JMethod onViewChanged;
 	private JBlock onViewChangedBody;


### PR DESCRIPTION
Implements #1442. The `AnnotationHelper` usages cannot be easily refactored, since different handlers use different subclasses of it.