### PR TITLE
Add @Field, @Part and @Path

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
@@ -215,6 +215,19 @@ public class ValidatorHelper {
 	}
 
 	private void hasOneOfAnnotations(Element reportElement, Element element, List<Class<? extends Annotation>> validAnnotations, ElementValidation validation) {
+		checkAnnotations(reportElement, element, validAnnotations, true, validation);
+	}
+
+	public void doesNotHaveOneOfAnnotations(Element element, List<Class<? extends Annotation>> validAnnotations, ElementValidation validation) {
+		checkAnnotations(element, element, validAnnotations, false, validation);
+	}
+
+	public void doesNotHaveAnnotation(Element element, Class<? extends Annotation> annotation, ElementValidation validation) {
+		doesNotHaveOneOfAnnotations(element, Collections.<Class<? extends Annotation>> singletonList(annotation), validation);
+	}
+
+	private void checkAnnotations(Element reportElement, Element element, List<Class<? extends Annotation>> validAnnotations, boolean shouldFind, ElementValidation validation) {
+
 		boolean foundAnnotation = false;
 		for (Class<? extends Annotation> validAnnotation : validAnnotations) {
 			if (element.getAnnotation(validAnnotation) != null) {
@@ -222,9 +235,12 @@ public class ValidatorHelper {
 				break;
 			}
 		}
-		if (!foundAnnotation) {
-			validation.addError(reportElement,
-					"%s can only be used in a " + element.getKind().toString().toLowerCase() + " annotated with " + getFormattedValidEnhancedBeanAnnotationTypes(validAnnotations) + ".");
+
+		if (shouldFind != foundAnnotation) {
+			String not = shouldFind ? "" : " not";
+
+			validation.addError(reportElement, "%s can only be used in a " + element.getKind().toString().toLowerCase() + not + " annotated with "
+					+ getFormattedValidEnhancedBeanAnnotationTypes(validAnnotations) + ".");
 		}
 	}
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
@@ -29,8 +29,8 @@ import static org.androidannotations.helper.ModelConstants.classSuffix;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -66,7 +66,7 @@ public class ValidatorHelper {
 
 	private static final List<String> ANDROID_FRAGMENT_QUALIFIED_NAMES = asList(CanonicalNameConstants.FRAGMENT, CanonicalNameConstants.SUPPORT_V4_FRAGMENT);
 
-	private static final Collection<Integer> VALID_LOG_LEVELS = Arrays.asList(LOG_VERBOSE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR);
+	private static final Collection<Integer> VALID_LOG_LEVELS = asList(LOG_VERBOSE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR);
 
 	private static final List<String> VALID_PREFERENCE_CLASSES = asList(CanonicalNameConstants.PREFERENCE_ACTIVITY, CanonicalNameConstants.PREFERENCE_FRAGMENT,
 			CanonicalNameConstants.SUPPORT_V4_PREFERENCE_FRAGMENT, CanonicalNameConstants.MACHINARIUS_V4_PREFERENCE_FRAGMENT, CanonicalNameConstants.SUPPORT_V7_PREFERENCE_FRAGMENTCOMPAT,
@@ -149,74 +149,72 @@ public class ValidatorHelper {
 		}
 	}
 
+	public void enclosingElementHasAnnotation(Class<? extends Annotation> annotation, Element element, ElementValidation validation) {
+		enclosingElementHasOneOfAnnotations(element, Collections.<Class<? extends Annotation>> singletonList(annotation), validation);
+	}
+
 	public void enclosingElementHasEBeanAnnotation(Element element, ElementValidation valid) {
-		Element enclosingElement = element.getEnclosingElement();
-		hasClassAnnotation(element, enclosingElement, EBean.class, valid);
+		enclosingElementHasAnnotation(EBean.class, element, valid);
 	}
 
 	public void enclosingElementHasEActivity(Element element, ElementValidation valid) {
-		Element enclosingElement = element.getEnclosingElement();
-		hasClassAnnotation(element, enclosingElement, EActivity.class, valid);
+		enclosingElementHasAnnotation(EActivity.class, element, valid);
 	}
 
 	public void enclosingElementHasEActivityOrEFragment(Element element, ElementValidation valid) {
-		Element enclosingElement = element.getEnclosingElement();
 		List<Class<? extends Annotation>> validAnnotations = asList(EActivity.class, EFragment.class);
-		hasOneOfClassAnnotations(element, enclosingElement, validAnnotations, valid);
+		enclosingElementHasOneOfAnnotations(element, validAnnotations, valid);
 	}
 
 	public void enclosingElementHasEActivityOrEFragmentOrEServiceOrEIntentService(Element element, ElementValidation valid) {
-		Element enclosingElement = element.getEnclosingElement();
 		List<Class<? extends Annotation>> validAnnotations = asList(EActivity.class, EFragment.class, EService.class, EIntentService.class);
-		hasOneOfClassAnnotations(element, enclosingElement, validAnnotations, valid);
+		enclosingElementHasOneOfAnnotations(element, validAnnotations, valid);
 	}
 
 	public void enclosingElementHasEFragment(Element element, ElementValidation valid) {
-		Element enclosingElement = element.getEnclosingElement();
-		hasClassAnnotation(element, enclosingElement, EFragment.class, valid);
+		enclosingElementHasAnnotation(EFragment.class, element, valid);
 	}
 
 	public void enclosingElementHasEIntentService(Element element, ElementValidation valid) {
-		Element enclosingElement = element.getEnclosingElement();
-		hasClassAnnotation(element, enclosingElement, EIntentService.class, valid);
+		enclosingElementHasAnnotation(EIntentService.class, element, valid);
 	}
 
 	public void enclosingElementHasEReceiver(Element element, ElementValidation valid) {
-		Element enclosingElement = element.getEnclosingElement();
-		hasClassAnnotation(element, enclosingElement, EReceiver.class, valid);
+		enclosingElementHasAnnotation(EReceiver.class, element, valid);
 	}
 
 	public void hasEActivity(Element element, ElementValidation valid) {
-		hasClassAnnotation(element, element, EActivity.class, valid);
+		hasAnnotation(element, element, EActivity.class, valid);
 	}
 
 	public void hasEActivityOrEFragment(Element element, ElementValidation valid) {
 		List<Class<? extends Annotation>> validAnnotations = asList(EActivity.class, EFragment.class);
-		hasOneOfClassAnnotations(element, element, validAnnotations, valid);
+		hasOneOfAnnotations(element, element, validAnnotations, valid);
 	}
 
 	public void enclosingElementHasEnhancedViewSupportAnnotation(Element element, ElementValidation valid) {
-		Element enclosingElement = element.getEnclosingElement();
-		hasOneOfClassAnnotations(element, enclosingElement, VALID_ENHANCED_VIEW_SUPPORT_ANNOTATIONS, valid);
+		enclosingElementHasOneOfAnnotations(element, VALID_ENHANCED_VIEW_SUPPORT_ANNOTATIONS, valid);
 	}
 
 	public void enclosingElementHasEnhancedComponentAnnotation(Element element, ElementValidation valid) {
-		Element enclosingElement = element.getEnclosingElement();
-		hasOneOfClassAnnotations(element, enclosingElement, VALID_ENHANCED_COMPONENT_ANNOTATIONS, valid);
+		enclosingElementHasOneOfAnnotations(element, VALID_ENHANCED_COMPONENT_ANNOTATIONS, valid);
 	}
 
 	public void enclosingElementHasAndroidAnnotation(Element element, ElementValidation valid) {
-		Element enclosingElement = element.getEnclosingElement();
-		hasOneOfClassAnnotations(element, enclosingElement, environment().getGeneratingAnnotations(), valid);
+		enclosingElementHasOneOfAnnotations(element, environment().getGeneratingAnnotations(), valid);
 	}
 
-	private void hasClassAnnotation(Element reportElement, Element element, Class<? extends Annotation> validAnnotation, ElementValidation valid) {
+	private void hasAnnotation(Element element, Element reportElement, Class<? extends Annotation> validAnnotation, ElementValidation valid) {
 		ArrayList<Class<? extends Annotation>> validAnnotations = new ArrayList<>();
 		validAnnotations.add(validAnnotation);
-		hasOneOfClassAnnotations(reportElement, element, validAnnotations, valid);
+		hasOneOfAnnotations(element, reportElement, validAnnotations, valid);
 	}
 
-	public void hasOneOfClassAnnotations(Element reportElement, Element element, List<Class<? extends Annotation>> validAnnotations, ElementValidation valid) {
+	public void enclosingElementHasOneOfAnnotations(Element element, List<Class<? extends Annotation>> validAnnotations, ElementValidation validation) {
+		hasOneOfAnnotations(element, element.getEnclosingElement(), validAnnotations, validation);
+	}
+
+	private void hasOneOfAnnotations(Element reportElement, Element element, List<Class<? extends Annotation>> validAnnotations, ElementValidation validation) {
 		boolean foundAnnotation = false;
 		for (Class<? extends Annotation> validAnnotation : validAnnotations) {
 			if (element.getAnnotation(validAnnotation) != null) {
@@ -225,7 +223,8 @@ public class ValidatorHelper {
 			}
 		}
 		if (!foundAnnotation) {
-			valid.addError(reportElement, "%s can only be used in a class annotated with " + getFormattedValidEnhancedBeanAnnotationTypes(validAnnotations) + ".");
+			validation.addError(reportElement,
+					"%s can only be used in a " + element.getKind().toString().toLowerCase() + " annotated with " + getFormattedValidEnhancedBeanAnnotationTypes(validAnnotations) + ".");
 		}
 	}
 
@@ -246,11 +245,6 @@ public class ValidatorHelper {
 	public void hasViewByIdAnnotation(Element element, ElementValidation valid) {
 		String error = "can only be used with annotation";
 		elementHasAnnotation(ViewById.class, element, valid, error);
-	}
-
-	public void enclosingMethodHasAnnotation(Class<? extends Annotation> annotation, Element element, ElementValidation valid) {
-		String error = "can only be used with a method annotated with";
-		enclosingElementHasAnnotation(annotation, element, valid, error);
 	}
 
 	public void enclosingElementHasAnnotation(Class<? extends Annotation> annotation, Element element, ElementValidation valid, String error) {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/ExtraParameterHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/ExtraParameterHandler.java
@@ -51,7 +51,7 @@ public abstract class ExtraParameterHandler extends BaseAnnotationHandler<Genera
 
 	@Override
 	protected void validate(Element element, ElementValidation valid) {
-		validatorHelper.enclosingMethodHasAnnotation(methodAnnotationClass, element, valid);
+		validatorHelper.enclosingElementHasAnnotation(methodAnnotationClass, element, valid);
 
 		validatorHelper.canBePutInABundle(element, valid);
 	}

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-api/src/main/java/org/androidannotations/rest/spring/annotations/Field.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-api/src/main/java/org/androidannotations/rest/spring/annotations/Field.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.rest.spring.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation can be used to add a form-encoded parameter to the request
+ * from a method parameter. The annotation value should be the name of the
+ * form-encoded parameter, if not specified, the method parameter name will be
+ * used as the name of the form-encoded parameter. This annotation only can be
+ * used with POST requests, hence the method must be annotated with {@link Post}
+ * . To use this annotation, you must add <code>FormHttpMessageConverter</code>
+ * to the list of converters.
+ *
+ * <blockquote>
+ *
+ * <b>Example :</b>
+ *
+ * <pre>
+ * &#064;Rest(rootUrl = &quot;http://myserver&quot;, converters = FormHttpMessageConverter.class)
+ * public interface RestClient {
+ *
+ * 	&#064;Post(&quot;/events/{id}&quot;)
+ * 	EventList addEvent(String id, <b>&#064;Field</b> String eventName);
+ * }
+ * </pre>
+ *
+ * </blockquote>
+ *
+ * @see Rest
+ * @see Post
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.PARAMETER)
+public @interface Field {
+
+	/**
+	 * Name of the form-encoded parameter.
+	 *
+	 * @return name of the parameter
+	 */
+	String value() default "";
+}

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-api/src/main/java/org/androidannotations/rest/spring/annotations/Part.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-api/src/main/java/org/androidannotations/rest/spring/annotations/Part.java
@@ -21,10 +21,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation can be used to add a form-encoded parameter to the request
+ * This annotation can be used to add a multi-part parameter to the POST request
  * from a method parameter. The annotation value should be the name of the
- * form-encoded parameter, if not specified, the method parameter name will be
- * used as the name of the form-encoded parameter. This annotation only can be
+ * multi-part parameter, if not specified, the method parameter name will be
+ * used as the name of the multi-part parameter. This annotation only can be
  * used with POST requests, hence the method must be annotated with {@link Post}
  * . To use this annotation, you must add <code>FormHttpMessageConverter</code>
  * to the list of converters.
@@ -38,22 +38,22 @@ import java.lang.annotation.Target;
  * public interface RestClient {
  *
  * 	&#064;Post(&quot;/events/{id}&quot;)
- * 	EventList addEvent(String id, <b>&#064;Field</b> String eventName);
+ * 	EventList addEvent(String id, <b>&#064;Part</b> FileResource image);
  * }
  * </pre>
  *
  * </blockquote>
  *
- * @see Rest
  * @see Post
  * @see Part
+ * @see Rest
  */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.PARAMETER)
-public @interface Field {
+public @interface Part {
 
 	/**
-	 * Name of the form-encoded parameter.
+	 * Name of the post parameter.
 	 *
 	 * @return name of the parameter
 	 */

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-api/src/main/java/org/androidannotations/rest/spring/annotations/Path.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-api/src/main/java/org/androidannotations/rest/spring/annotations/Path.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.rest.spring.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation can be used to mark a method parameter to be an url variable.
+ * This annotation is optional, because method parameters which are not
+ * annotated with any annotation or not correspond to the request entity,
+ * implicitly interpreted as url variables. However with this annotation you can
+ * explicitly mark them. Also, with the annotation value, you can add another
+ * name to the url variable. If an url variable method parameter does not have
+ * the {@link Path} annotation, or the annotation value is not specified, the
+ * method parameter name will be used as the url variable name. The url in the
+ * {@link Get} etc. annotation must contain an url variable, which the
+ * corresponding method variable will be substituted into.
+ *
+ * <blockquote>
+ *
+ * <b>Example :</b>
+ *
+ * <pre>
+ * &#064;Rest(converters = MappingJacksonHttpMessageConverter.class)
+ * public interface MyRestClient {
+ *
+ * 	&#064;Get(&quot;/event/<b>{id}</b>&quot;)
+ * 	Event getEvent(String <b>id</b>);
+ *
+ * 	&#064;Get(&quot;/event/<b>{id}</b>&quot;)
+ * 	Event getEventWithPathAnnotation(&#064;Path String <b>id</b>);
+ *
+ * 	&#064;Get(&quot;/event/<b>{id}</b>&quot;)
+ * 	Event getEventWithPathAnnotationValue(&#064;Path(&quot;<b>id</b>&quot;) String identifier);
+ * }
+ * </pre>
+ *
+ * </blockquote>
+ *
+ * @see Rest
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.PARAMETER)
+public @interface Path {
+
+	/**
+	 * Name of the url variable.
+	 *
+	 * @return the url variable name
+	 */
+	String value() default "";
+}

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/main/java/org/androidannotations/rest/spring/test/MyService.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/main/java/org/androidannotations/rest/spring/test/MyService.java
@@ -25,6 +25,7 @@ import org.androidannotations.rest.spring.annotations.Field;
 import org.androidannotations.rest.spring.annotations.Get;
 import org.androidannotations.rest.spring.annotations.Head;
 import org.androidannotations.rest.spring.annotations.Options;
+import org.androidannotations.rest.spring.annotations.Part;
 import org.androidannotations.rest.spring.annotations.Path;
 import org.androidannotations.rest.spring.annotations.Post;
 import org.androidannotations.rest.spring.annotations.Put;
@@ -158,6 +159,12 @@ public interface MyService {
 	@RequiresCookie("myCookie")
 	@RequiresCookieInUrl("myCookieInUrl")
 	void addEventWithParameters(String date, @Field String parameter, @Field String otherParameter);
+
+	@Post("/events/{date}")
+	@RequiresHeader("SomeFancyHeader")
+	@RequiresCookie("myCookie")
+	@RequiresCookieInUrl("myCookieInUrl")
+	void addEventWithParts(String date, @Part String parameter, @Part String otherParameter);
 
 	@Post("/events/{date}")
 	@RequiresHeader("SomeFancyHeader")

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/main/java/org/androidannotations/rest/spring/test/MyService.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/main/java/org/androidannotations/rest/spring/test/MyService.java
@@ -21,9 +21,11 @@ import java.util.Set;
 
 import org.androidannotations.rest.spring.annotations.Accept;
 import org.androidannotations.rest.spring.annotations.Delete;
+import org.androidannotations.rest.spring.annotations.Field;
 import org.androidannotations.rest.spring.annotations.Get;
 import org.androidannotations.rest.spring.annotations.Head;
 import org.androidannotations.rest.spring.annotations.Options;
+import org.androidannotations.rest.spring.annotations.Path;
 import org.androidannotations.rest.spring.annotations.Post;
 import org.androidannotations.rest.spring.annotations.Put;
 import org.androidannotations.rest.spring.annotations.RequiresAuthentication;
@@ -149,6 +151,12 @@ public interface MyService {
 
 	@Post("/events/")
 	ResponseEntity<Event> addEvent2(Event event);
+
+	@Post("/events/{date}")
+	@RequiresHeader("SomeFancyHeader")
+	@RequiresCookie("myCookie")
+	@RequiresCookieInUrl("myCookieInUrl")
+	void addEventWithPathParameters(@Path("date") String pathParam, @Field String parameter);
 
 	/**
 	 * Output different then input

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/main/java/org/androidannotations/rest/spring/test/MyService.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/main/java/org/androidannotations/rest/spring/test/MyService.java
@@ -39,14 +39,15 @@ import org.springframework.http.HttpAuthentication;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJacksonHttpMessageConverter;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 // if defined, the rootUrl will be added as a prefix to every request
-@Rest(rootUrl = "http://company.com/ajax/services", converters = { MappingJacksonHttpMessageConverter.class, EBeanConverter.class },
-		interceptors = { RequestInterceptor.class, EBeanInterceptor.class },
-		requestFactory = MyRequestFactory.class)
+@Rest(rootUrl = "http://company.com/ajax/services", converters = { MappingJacksonHttpMessageConverter.class, EBeanConverter.class, FormHttpMessageConverter.class }, //
+				interceptors = { RequestInterceptor.class, EBeanInterceptor.class }, //
+				requestFactory = MyRequestFactory.class)
 public interface MyService {
 
 	// *** GET ***
@@ -151,6 +152,12 @@ public interface MyService {
 
 	@Post("/events/")
 	ResponseEntity<Event> addEvent2(Event event);
+
+	@Post("/events/{date}")
+	@RequiresHeader("SomeFancyHeader")
+	@RequiresCookie("myCookie")
+	@RequiresCookieInUrl("myCookieInUrl")
+	void addEventWithParameters(String date, @Field String parameter, @Field String otherParameter);
 
 	@Post("/events/{date}")
 	@RequiresHeader("SomeFancyHeader")

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/main/java/org/androidannotations/rest/spring/test/PathRestService.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/main/java/org/androidannotations/rest/spring/test/PathRestService.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.rest.spring.test;
+
+import org.androidannotations.rest.spring.annotations.Get;
+import org.androidannotations.rest.spring.annotations.Path;
+import org.androidannotations.rest.spring.annotations.Rest;
+import org.androidannotations.rest.spring.api.RestClientSupport;
+import org.springframework.http.converter.StringHttpMessageConverter;
+
+@Rest(converters = { StringHttpMessageConverter.class })
+public interface PathRestService extends RestClientSupport {
+
+	@Get(value = "{hello}{bye}{parameterName}")
+	void get(@Path("hello") String bye, @Path("bye") String hello, String parameterName);
+}

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/main/java/org/androidannotations/rest/spring/test/PostRestService.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/main/java/org/androidannotations/rest/spring/test/PostRestService.java
@@ -16,6 +16,7 @@
 package org.androidannotations.rest.spring.test;
 
 import org.androidannotations.rest.spring.annotations.Field;
+import org.androidannotations.rest.spring.annotations.Part;
 import org.androidannotations.rest.spring.annotations.Post;
 import org.androidannotations.rest.spring.annotations.Rest;
 import org.androidannotations.rest.spring.api.RestClientSupport;
@@ -26,4 +27,7 @@ public interface PostRestService extends RestClientSupport {
 
 	@Post("/")
 	void post(@Field("otherParam") String postParam, @Field("postParam") String otherParam, @Field String thirdParam);
+
+	@Post("/")
+	void multipart(@Part("otherParam") String postParam, @Part("postParam") String otherParam, @Part String thirdParam);
 }

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/main/java/org/androidannotations/rest/spring/test/PostRestService.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/main/java/org/androidannotations/rest/spring/test/PostRestService.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.rest.spring.test;
+
+import org.androidannotations.rest.spring.annotations.Field;
+import org.androidannotations.rest.spring.annotations.Post;
+import org.androidannotations.rest.spring.annotations.Rest;
+import org.androidannotations.rest.spring.api.RestClientSupport;
+import org.springframework.http.converter.FormHttpMessageConverter;
+
+@Rest(converters = { FormHttpMessageConverter.class })
+public interface PostRestService extends RestClientSupport {
+
+	@Post("/")
+	void post(@Field("otherParam") String postParam, @Field("postParam") String otherParam, @Field String thirdParam);
+}

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/test/java/org/androidannotations/rest/spring/test/MyServiceTest.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/test/java/org/androidannotations/rest/spring/test/MyServiceTest.java
@@ -274,4 +274,19 @@ public class MyServiceTest {
 				});
 	}
 
+	@Test
+	public void addEventWithPathParameters() {
+		RequestTestBuilder.build() //
+				.requestCookie("myCookie", "myCookieValue") //
+				.requestHeader("SomeFancyHeader", "aFancyHeader") //
+				.responseContent("{'id':1,'name':'event1'}") //
+				.hasUrlVariables(true) //
+				.asserts(new RequestTestBuilder.RequestTestBuilderExecutor() {
+					@Override
+					public void execute(MyService myService) {
+						myService.addEventWithPathParameters("now", "param1");
+					}
+				});
+	}
+
 }

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/test/java/org/androidannotations/rest/spring/test/MyServiceTest.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/test/java/org/androidannotations/rest/spring/test/MyServiceTest.java
@@ -290,6 +290,22 @@ public class MyServiceTest {
 	}
 
 	@Test
+	public void addEventWithParts() {
+		RequestTestBuilder.build() //
+				.requestCookie("myCookie", "myCookieValue") //
+				.requestHeader("SomeFancyHeader", "aFancyHeader") //
+				.expectedHeader("Content-Type", "multipart/form-data") //
+				.responseContent("{'id':1,'name':'event1'}") //
+				.hasUrlVariables(true) //
+				.asserts(new RequestTestBuilder.RequestTestBuilderExecutor() {
+					@Override
+					public void execute(MyService myService) {
+						myService.addEventWithParts("now", "param1", "param2");
+					}
+				});
+	}
+
+	@Test
 	public void addEventWithPathParameters() {
 		RequestTestBuilder.build() //
 				.requestCookie("myCookie", "myCookieValue") //

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/test/java/org/androidannotations/rest/spring/test/MyServiceTest.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/test/java/org/androidannotations/rest/spring/test/MyServiceTest.java
@@ -275,6 +275,21 @@ public class MyServiceTest {
 	}
 
 	@Test
+	public void addEventWithParameters() {
+		RequestTestBuilder.build() //
+				.requestCookie("myCookie", "myCookieValue") //
+				.requestHeader("SomeFancyHeader", "aFancyHeader") //
+				.responseContent("{'id':1,'name':'event1'}") //
+				.hasUrlVariables(true) //
+				.asserts(new RequestTestBuilder.RequestTestBuilderExecutor() {
+					@Override
+					public void execute(MyService myService) {
+						myService.addEventWithParameters("now", "param1", "param2");
+					}
+				});
+	}
+
+	@Test
 	public void addEventWithPathParameters() {
 		RequestTestBuilder.build() //
 				.requestCookie("myCookie", "myCookieValue") //

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/test/java/org/androidannotations/rest/spring/test/PathRestServiceTest.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/test/java/org/androidannotations/rest/spring/test/PathRestServiceTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.rest.spring.test;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.robolectric.RobolectricTestRunner;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestTemplate;
+
+@RunWith(RobolectricTestRunner.class)
+public class PathRestServiceTest {
+
+	@Test
+	public void useAnnotationValueForUrlVariable() {
+		PathRestService pathRestService = new PathRestService_(null);
+
+		RestTemplate restTemplate = mock(RestTemplate.class);
+		pathRestService.setRestTemplate(restTemplate);
+
+		pathRestService.get("first", "second", "last");
+
+		@SuppressWarnings("checkstyle:illegaltype")
+		HashMap<String, Object> urlVariables = new HashMap<String, Object>();
+		urlVariables.put("hello", "first");
+		urlVariables.put("parameterName", "last");
+		urlVariables.put("bye", "second");
+
+		verify(restTemplate).exchange(anyString(), eq(HttpMethod.GET), Matchers.<HttpEntity<?>> any(), Matchers.<Class<Object>> any(), eq(urlVariables));
+	}
+
+}

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/test/java/org/androidannotations/rest/spring/test/PostRestServiceTest.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/test/java/org/androidannotations/rest/spring/test/PostRestServiceTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
@@ -34,15 +35,32 @@ import org.springframework.web.client.RestTemplate;
 @RunWith(RobolectricTestRunner.class)
 public class PostRestServiceTest {
 
+	PostRestService_ service;
+
+	RestTemplate restTemplate;
+
+	@Before
+	public void setUp() {
+		service = new PostRestService_(null);
+		restTemplate = mock(RestTemplate.class);
+		service.setRestTemplate(restTemplate);
+	}
+
 	@Test
 	public void injectsPostParametersIntoRequestEntity() {
-		PostRestService_ service = new PostRestService_(null);
-
-		RestTemplate restTemplate = mock(RestTemplate.class);
-		service.setRestTemplate(restTemplate);
-
 		service.post("first", "second", "last");
 
+		verifyPostParametersAdded();
+	}
+
+	@Test
+	public void injectsMultipartPostParametersIntoRequestEntity() {
+		service.multipart("first", "second", "last");
+
+		verifyPostParametersAdded();
+	}
+
+	private void verifyPostParametersAdded() {
 		LinkedMultiValueMap<String, Object> postParameters = new LinkedMultiValueMap<String, Object>();
 		postParameters.add("thirdParam", "last");
 		postParameters.add("otherParam", "first");

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/test/java/org/androidannotations/rest/spring/test/PostRestServiceTest.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/test/java/org/androidannotations/rest/spring/test/PostRestServiceTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.rest.spring.test;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Matchers;
+import org.robolectric.RobolectricTestRunner;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@RunWith(RobolectricTestRunner.class)
+public class PostRestServiceTest {
+
+	@Test
+	public void injectsPostParametersIntoRequestEntity() {
+		PostRestService_ service = new PostRestService_(null);
+
+		RestTemplate restTemplate = mock(RestTemplate.class);
+		service.setRestTemplate(restTemplate);
+
+		service.post("first", "second", "last");
+
+		LinkedMultiValueMap<String, Object> postParameters = new LinkedMultiValueMap<String, Object>();
+		postParameters.add("thirdParam", "last");
+		postParameters.add("otherParam", "first");
+		postParameters.add("postParam", "second");
+
+		HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = new HttpEntity<LinkedMultiValueMap<String, Object>>(postParameters);
+
+		verify(restTemplate).exchange(anyString(), eq(HttpMethod.POST), argThat(equals(requestEntity)), Matchers.<Class<Object>> any());
+	}
+
+	private static <T> ArgumentMatcher<HttpEntity<T>> equals(final HttpEntity<T> expected) {
+		return new ArgumentMatcher<HttpEntity<T>>() {
+
+			@Override
+			public boolean matches(Object argument) {
+				HttpEntity<?> actual = (HttpEntity<?>) argument;
+				return expected.getBody().equals(actual.getBody());
+			}
+		};
+	}
+
+}

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/test/java/org/androidannotations/rest/spring/test/RequestTestBuilder.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-test/src/test/java/org/androidannotations/rest/spring/test/RequestTestBuilder.java
@@ -63,6 +63,11 @@ public class RequestTestBuilder {
 		return this;
 	}
 
+	public RequestTestBuilder expectedHeader(String name, String value) {
+		requestHeaders.put(name, value);
+		return this;
+	}
+
 	public RequestTestBuilder requestCookie(String name, String value) {
 		requestCookies.put(name, value);
 		myService.setCookie(name, value);

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/RestSpringPlugin.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/RestSpringPlugin.java
@@ -25,6 +25,7 @@ import org.androidannotations.rest.spring.handler.DeleteHandler;
 import org.androidannotations.rest.spring.handler.GetHandler;
 import org.androidannotations.rest.spring.handler.HeadHandler;
 import org.androidannotations.rest.spring.handler.OptionsHandler;
+import org.androidannotations.rest.spring.handler.PathHandler;
 import org.androidannotations.rest.spring.handler.PostHandler;
 import org.androidannotations.rest.spring.handler.PutHandler;
 import org.androidannotations.rest.spring.handler.RestHandler;
@@ -49,6 +50,7 @@ public class RestSpringPlugin extends AndroidAnnotationsPlugin {
 		annotationHandlers.add(new DeleteHandler(androidAnnotationEnv));
 		annotationHandlers.add(new HeadHandler(androidAnnotationEnv));
 		annotationHandlers.add(new OptionsHandler(androidAnnotationEnv));
+		annotationHandlers.add(new PathHandler(androidAnnotationEnv));
 		annotationHandlers.add(new RestServiceHandler(androidAnnotationEnv));
 		return annotationHandlers;
 	}

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/handler/PathHandler.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/handler/PathHandler.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.rest.spring.handler;
+
+import javax.lang.model.element.Element;
+
+import org.androidannotations.AndroidAnnotationsEnvironment;
+import org.androidannotations.ElementValidation;
+import org.androidannotations.handler.BaseAnnotationHandler;
+import org.androidannotations.holder.GeneratedClassHolder;
+import org.androidannotations.rest.spring.annotations.Path;
+import org.androidannotations.rest.spring.helper.RestSpringValidatorHelper;
+
+public class PathHandler extends BaseAnnotationHandler<GeneratedClassHolder> {
+
+	private RestSpringValidatorHelper restValidatorHelper;
+
+	public PathHandler(AndroidAnnotationsEnvironment environment) {
+		super(Path.class, environment);
+		restValidatorHelper = new RestSpringValidatorHelper(environment, getTarget());
+	}
+
+	@Override
+	protected void validate(Element element, ElementValidation validation) {
+		restValidatorHelper.enclosingElementHasOneOfRestMethodAnnotations(element, validation);
+
+		if (validation.isValid()) {
+			restValidatorHelper.urlVariableNameExistsInEnclosingAnnotation(element, validation);
+		}
+	}
+
+	@Override
+	public void process(Element element, GeneratedClassHolder holder) throws Exception {
+		// Don't do anything here.
+	}
+
+}

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/handler/PathHandler.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/handler/PathHandler.java
@@ -35,6 +35,8 @@ public class PathHandler extends BaseAnnotationHandler<GeneratedClassHolder> {
 
 	@Override
 	protected void validate(Element element, ElementValidation validation) {
+		restValidatorHelper.doesNotHaveFieldAnnotation(element, validation);
+
 		restValidatorHelper.enclosingElementHasOneOfRestMethodAnnotations(element, validation);
 
 		if (validation.isValid()) {

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/handler/PostHandler.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/handler/PostHandler.java
@@ -15,17 +15,33 @@
  */
 package org.androidannotations.rest.spring.handler;
 
+import java.util.Collections;
+
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 
 import org.androidannotations.AndroidAnnotationsEnvironment;
 import org.androidannotations.ElementValidation;
+import org.androidannotations.handler.AnnotationHandler;
+import org.androidannotations.handler.BaseAnnotationHandler;
+import org.androidannotations.handler.HasParameterHandlers;
+import org.androidannotations.holder.GeneratedClassHolder;
+import org.androidannotations.rest.spring.annotations.Field;
 import org.androidannotations.rest.spring.annotations.Post;
+import org.androidannotations.rest.spring.holder.RestHolder;
 
-public class PostHandler extends RestMethodHandler {
+public class PostHandler extends RestMethodHandler implements HasParameterHandlers<RestHolder> {
+
+	private FieldHandler fieldHandler;
 
 	public PostHandler(AndroidAnnotationsEnvironment environment) {
 		super(Post.class, environment);
+		fieldHandler = new FieldHandler(environment);
+	}
+
+	@Override
+	public Iterable<AnnotationHandler> getParameterHandlers() {
+		return Collections.<AnnotationHandler> singleton(fieldHandler);
 	}
 
 	@Override
@@ -41,5 +57,22 @@ public class PostHandler extends RestMethodHandler {
 	protected String getUrlSuffix(Element element) {
 		Post annotation = element.getAnnotation(Post.class);
 		return annotation.value();
+	}
+
+	public class FieldHandler extends BaseAnnotationHandler<GeneratedClassHolder> {
+
+		public FieldHandler(AndroidAnnotationsEnvironment environment) {
+			super(Field.class, environment);
+		}
+
+		@Override
+		protected void validate(Element element, ElementValidation validation) {
+			validatorHelper.enclosingMethodHasAnnotation(Post.class, element, validation);
+		}
+
+		@Override
+		public void process(Element element, GeneratedClassHolder holder) throws Exception {
+			// Don't do anything here.
+		}
 	}
 }

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/handler/PostHandler.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/handler/PostHandler.java
@@ -67,7 +67,7 @@ public class PostHandler extends RestMethodHandler implements HasParameterHandle
 
 		@Override
 		protected void validate(Element element, ElementValidation validation) {
-			validatorHelper.enclosingMethodHasAnnotation(Post.class, element, validation);
+			validatorHelper.enclosingElementHasAnnotation(Post.class, element, validation);
 		}
 
 		@Override

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/handler/PostHandler.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/handler/PostHandler.java
@@ -15,7 +15,7 @@
  */
 package org.androidannotations.rest.spring.handler;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.SortedMap;
 
@@ -29,6 +29,7 @@ import org.androidannotations.handler.BaseAnnotationHandler;
 import org.androidannotations.handler.HasParameterHandlers;
 import org.androidannotations.holder.GeneratedClassHolder;
 import org.androidannotations.rest.spring.annotations.Field;
+import org.androidannotations.rest.spring.annotations.Part;
 import org.androidannotations.rest.spring.annotations.Post;
 import org.androidannotations.rest.spring.helper.RestSpringClasses;
 import org.androidannotations.rest.spring.holder.RestHolder;
@@ -42,15 +43,17 @@ import com.sun.codemodel.JVar;
 public class PostHandler extends RestMethodHandler implements HasParameterHandlers<RestHolder> {
 
 	private FieldHandler fieldHandler;
+	private PartHandler partHandler;
 
 	public PostHandler(AndroidAnnotationsEnvironment environment) {
 		super(Post.class, environment);
 		fieldHandler = new FieldHandler(environment);
+		partHandler = new PartHandler(environment);
 	}
 
 	@Override
 	public Iterable<AnnotationHandler> getParameterHandlers() {
-		return Collections.<AnnotationHandler> singleton(fieldHandler);
+		return Arrays.<AnnotationHandler> asList(fieldHandler, partHandler);
 	}
 
 	@Override
@@ -60,6 +63,8 @@ public class PostHandler extends RestMethodHandler implements HasParameterHandle
 		validatorHelper.doesNotReturnPrimitive((ExecutableElement) element, validation);
 
 		restSpringValidatorHelper.urlVariableNamesExistInParametersAndHasOnlyOneEntityParameterOrOneOrMorePostParameter((ExecutableElement) element, validation);
+
+		restSpringValidatorHelper.doesNotMixPartAndFieldAnnotations((ExecutableElement) element, validation);
 	}
 
 	@Override
@@ -89,10 +94,10 @@ public class PostHandler extends RestMethodHandler implements HasParameterHandle
 		return restAnnotationHelper.declareHttpEntity(methodBody, entitySentToServer, httpHeaders);
 	}
 
-	public class FieldHandler extends BaseAnnotationHandler<GeneratedClassHolder> {
+	private abstract class AbstractPostParamHandler extends BaseAnnotationHandler<GeneratedClassHolder> {
 
-		public FieldHandler(AndroidAnnotationsEnvironment environment) {
-			super(Field.class, environment);
+		AbstractPostParamHandler(Class<?> targetClass, AndroidAnnotationsEnvironment environment) {
+			super(targetClass, environment);
 		}
 
 		@Override
@@ -107,6 +112,34 @@ public class PostHandler extends RestMethodHandler implements HasParameterHandle
 		@Override
 		public void process(Element element, GeneratedClassHolder holder) throws Exception {
 			// Don't do anything here.
+		}
+	}
+
+	public class FieldHandler extends AbstractPostParamHandler {
+
+		public FieldHandler(AndroidAnnotationsEnvironment environment) {
+			super(Field.class, environment);
+		}
+
+		@Override
+		protected void validate(Element element, ElementValidation validation) {
+			super.validate(element, validation);
+
+			restSpringValidatorHelper.doesNotHavePartAnnotation(element, validation);
+		}
+	}
+
+	public class PartHandler extends AbstractPostParamHandler {
+
+		public PartHandler(AndroidAnnotationsEnvironment environment) {
+			super(Part.class, environment);
+		}
+
+		@Override
+		protected void validate(Element element, ElementValidation validation) {
+			super.validate(element, validation);
+
+			restSpringValidatorHelper.doesNotHaveFieldAnnotation(element, validation);
 		}
 	}
 }

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/helper/RestAnnotationHelper.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/helper/RestAnnotationHelper.java
@@ -21,9 +21,11 @@ import static org.androidannotations.rest.spring.helper.RestSpringClasses.MEDIA_
 import static org.androidannotations.rest.spring.helper.RestSpringClasses.RESPONSE_ENTITY;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeSet;
@@ -34,6 +36,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
@@ -45,6 +48,7 @@ import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.CanonicalNameConstants;
 import org.androidannotations.helper.TargetAnnotationHelper;
 import org.androidannotations.rest.spring.annotations.Accept;
+import org.androidannotations.rest.spring.annotations.Path;
 import org.androidannotations.rest.spring.annotations.RequiresAuthentication;
 import org.androidannotations.rest.spring.annotations.RequiresCookie;
 import org.androidannotations.rest.spring.annotations.RequiresCookieInUrl;
@@ -74,9 +78,15 @@ public class RestAnnotationHelper extends TargetAnnotationHelper {
 	private static final Pattern NAMES_PATTERN = Pattern.compile("\\{([^/]+?)\\}");
 
 	public Set<String> extractUrlVariableNames(ExecutableElement element) {
+		String uriTemplate = extractAnnotationValueParameter(element);
+
+		return extractUrlVariableNames(uriTemplate);
+	}
+
+
+	public Set<String> extractUrlVariableNames(String uriTemplate) {
 
 		Set<String> variableNames = new HashSet<>();
-		String uriTemplate = extractAnnotationValueParameter(element);
 
 		boolean hasValueInAnnotation = uriTemplate != null;
 		if (hasValueInAnnotation) {
@@ -90,6 +100,11 @@ public class RestAnnotationHelper extends TargetAnnotationHelper {
 	}
 
 	public JVar declareUrlVariables(ExecutableElement element, RestHolder holder, JBlock methodBody, SortedMap<String, JVar> methodParams) {
+		Map<String, String> urlNameToElementName = new HashMap<>();
+		for (VariableElement variableElement : element.getParameters()) {
+			urlNameToElementName.put(getUrlVariableCorrespondingTo(variableElement), variableElement.getSimpleName().toString());
+		}
+
 		Set<String> urlVariables = extractUrlVariableNames(element);
 
 		// cookies in url?
@@ -104,10 +119,16 @@ public class RestAnnotationHelper extends TargetAnnotationHelper {
 		if (!urlVariables.isEmpty()) {
 			JVar hashMapVar = methodBody.decl(hashMapClass, "urlVariables", JExpr._new(hashMapClass));
 			for (String urlVariable : urlVariables) {
-				JVar methodParam = methodParams.get(urlVariable);
+				String elementName = urlNameToElementName.get(urlVariable);
+				JVar methodParam = null;
+
+				if (elementName != null) {
+					methodParam = methodParams.get(elementName);
+				}
+
 				if (methodParam != null) {
 					methodBody.invoke(hashMapVar, "put").arg(urlVariable).arg(methodParam);
-					methodParams.remove(urlVariable);
+					methodParams.remove(elementName);
 				} else {
 					// cookie from url
 					JInvocation cookieValue = holder.getAvailableCookiesField().invoke("get").arg(JExpr.lit(urlVariable));
@@ -246,12 +267,25 @@ public class RestAnnotationHelper extends TargetAnnotationHelper {
 
 	public JVar getEntitySentToServer(ExecutableElement element, SortedMap<String, JVar> params) {
 		Set<String> urlVariables = extractUrlVariableNames(element);
-		for (String paramName : params.keySet()) {
-			if (!urlVariables.contains(paramName)) {
-				return params.get(paramName);
+		for (VariableElement parameter : element.getParameters()) {
+			String parametername = getUrlVariableCorrespondingTo(parameter);
+
+			if (!urlVariables.contains(parametername)) {
+				return params.get(parametername);
 			}
 		}
 		return null;
+	}
+
+	public String getUrlVariableCorrespondingTo(VariableElement parameter) {
+		Path path = parameter.getAnnotation(Path.class);
+		String parameterName;
+		if (path != null && !path.value().equals("")) {
+			parameterName = path.value();
+		} else {
+			parameterName = parameter.getSimpleName().toString();
+		}
+		return parameterName;
 	}
 
 	public JExpression declareHttpEntity(JBlock body, JVar entitySentToServer, JVar httpHeaders) {

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/helper/RestSpringClasses.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/helper/RestSpringClasses.java
@@ -31,6 +31,8 @@ public final class RestSpringClasses {
 	public static final String REST_CLIENT_EXCEPTION = "org.springframework.web.client.RestClientException";
 	public static final String NESTED_RUNTIME_EXCEPTION = "org.springframework.core.NestedRuntimeException";
 	public static final String RESPONSE_ERROR_HANDLER = "org.springframework.web.client.ResponseErrorHandler";
+	public static final String LINKED_MULTI_VALUE_MAP = "org.springframework.util.LinkedMultiValueMap";
+	public static final String FORM_HTTP_MESSAGE_CONVERTER = "org.springframework.http.converter.FormHttpMessageConverter";
 	public static final String PARAMETERIZED_TYPE_REFERENCE = "org.springframework.core.ParameterizedTypeReference";
 
 	private RestSpringClasses() {

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/helper/RestSpringValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/helper/RestSpringValidatorHelper.java
@@ -54,6 +54,7 @@ import org.androidannotations.rest.spring.annotations.Field;
 import org.androidannotations.rest.spring.annotations.Get;
 import org.androidannotations.rest.spring.annotations.Head;
 import org.androidannotations.rest.spring.annotations.Options;
+import org.androidannotations.rest.spring.annotations.Part;
 import org.androidannotations.rest.spring.annotations.Path;
 import org.androidannotations.rest.spring.annotations.Post;
 import org.androidannotations.rest.spring.annotations.Put;
@@ -364,7 +365,7 @@ public class RestSpringValidatorHelper extends ValidatorHelper {
 
 		Set<String> parametersName = new HashSet<>();
 		for (VariableElement parameter : parameters) {
-			if (parameter.getAnnotation(Field.class) != null) {
+			if (restAnnotationHelper.hasPostParameterAnnotation(parameter)) {
 				continue;
 			}
 
@@ -444,6 +445,28 @@ public class RestSpringValidatorHelper extends ValidatorHelper {
 		}
 	}
 
+	public void doesNotMixPartAndFieldAnnotations(ExecutableElement element, ElementValidation validation) {
+		boolean partFound = false;
+		boolean fieldFound = false;
+
+		for (VariableElement parameter : element.getParameters()) {
+			Part part = parameter.getAnnotation(Part.class);
+			if (part != null) {
+				partFound = true;
+			}
+
+			Field field = parameter.getAnnotation(Field.class);
+			if (field != null) {
+				fieldFound = true;
+			}
+		}
+
+		if (partFound && fieldFound) {
+			validation.addError(element, "Only one of @Part and @Field annotations can be used on the same method's parameters, not both.");
+		}
+	}
+
+
 	public void urlVariableNameExistsInEnclosingAnnotation(Element element, ElementValidation validation) {
 		Set<String> validRestMethodAnnotationNames = new HashSet<>();
 
@@ -509,6 +532,10 @@ public class RestSpringValidatorHelper extends ValidatorHelper {
 
 	public void doesNotHaveFieldAnnotation(Element element, ElementValidation validation) {
 		doesNotHaveAnnotation(element, Field.class, validation);
+	}
+
+	public void doesNotHavePartAnnotation(Element element, ElementValidation validation) {
+		doesNotHaveAnnotation(element, Part.class, validation);
 	}
 
 	public void restInterfaceHasFormConverter(Element element, ElementValidation validation) {

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/ClientWithMissingFormConverter.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/ClientWithMissingFormConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.rest.spring;
+
+
+import org.androidannotations.rest.spring.annotations.Field;
+import org.androidannotations.rest.spring.annotations.Post;
+import org.androidannotations.rest.spring.annotations.Rest;
+import org.springframework.http.converter.StringHttpMessageConverter;
+
+@Rest(converters = StringHttpMessageConverter.class)
+public interface ClientWithMissingFormConverter {
+
+	@Post("/")
+	void post(@Field String param);
+}

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/ClientWithPathVariable.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/ClientWithPathVariable.java
@@ -21,6 +21,7 @@ import org.androidannotations.rest.spring.annotations.Delete;
 import org.androidannotations.rest.spring.annotations.Get;
 import org.androidannotations.rest.spring.annotations.Head;
 import org.androidannotations.rest.spring.annotations.Options;
+import org.androidannotations.rest.spring.annotations.Path;
 import org.androidannotations.rest.spring.annotations.Post;
 import org.androidannotations.rest.spring.annotations.Put;
 import org.androidannotations.rest.spring.annotations.Rest;
@@ -49,4 +50,12 @@ public interface ClientWithPathVariable {
 	@Put("/test/{v1}/{v2}")
 	void putWithParameterEntity(int v1, String v2);
 
+	@Get("/test/{v1}")
+	void getWithPathAnnotation(@Path("v1") int version);
+
+	@Get("/test/{v1}/{v2}")
+	void getWithPathAnnotationAndParam(@Path("v1") int v1, String v2);
+
+	@Get("/test/{v1}/{v2}")
+	void getWithCrossParamAnnotations(@Path("v1") int v2, @Path("v2") int v1);
 }

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/ClientWithPostParameters.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/ClientWithPostParameters.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.rest.spring;
+
+import org.androidannotations.rest.spring.annotations.Field;
+import org.androidannotations.rest.spring.annotations.Post;
+import org.androidannotations.rest.spring.annotations.Rest;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.converter.FormHttpMessageConverter;
+
+@Rest(converters = FormHttpMessageConverter.class)
+public interface ClientWithPostParameters {
+
+	@Post("/")
+	void emptyPost();
+
+	@Post("/")
+	void oneField(@Field String a);
+
+	@Post("/")
+	void oneFieldWithName(@Field("b") String a);
+
+	@Post("/")
+	void twoField(@Field String a, @Field String b);
+
+	@Post("/")
+	void twoFieldsWithName(@Field String a, @Field("c") String b);
+
+	@Post("/")
+	void twoFieldsWithCrossName(@Field("b") String a, @Field("a") String b);
+
+	@Post("/")
+	void twoFieldssOneWithName(@Field String a, @Field("c") String b);
+
+	@Post("/{url}")
+	void fieldAndUrlVariable(@Field String a, String url);
+
+	@Post("/")
+	void fieldClassPathResource(@Field ClassPathResource res);
+}
+

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/ClientWithWrongFields.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/ClientWithWrongFields.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.rest.spring;
+
+import org.androidannotations.rest.spring.annotations.Field;
+import org.androidannotations.rest.spring.annotations.Path;
+import org.androidannotations.rest.spring.annotations.Post;
+import org.androidannotations.rest.spring.annotations.Rest;
+import org.springframework.http.converter.FormHttpMessageConverter;
+
+@Rest(converters = FormHttpMessageConverter.class)
+public interface ClientWithWrongFields {
+
+	@Post("/duplicateField")
+	void duplicateField(@Field("v1") int v1, @Field("v1") int v2);
+
+	@Post("/conflictWithPathParam")
+	void conflictWithPathParam(@Field("pathParamConflict") int v1, @Path("pathParamConflict") int v2);
+
+	@Post("/conflictWithPathParamWithElementName")
+	void conflictWithPathParamWithElementName(@Field("elementNameConflict") int v1, @Path("elementNameConflict") int elementNameConflict);
+
+	@Post("/conflictElementNameWithPathParam")
+	void conflictElementNameWithPathParam(@Field int conflict, @Path("conflict") int v2);
+
+	@Post("/pathParamAndEntity")
+	void fieldAndEntity(@Field int v1, String entity);
+
+	void missingPostAnnotation(@Field("missingPost") int v1);
+}

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/ClientWithWrongFields.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/ClientWithWrongFields.java
@@ -16,6 +16,7 @@
 package org.androidannotations.rest.spring;
 
 import org.androidannotations.rest.spring.annotations.Field;
+import org.androidannotations.rest.spring.annotations.Part;
 import org.androidannotations.rest.spring.annotations.Path;
 import org.androidannotations.rest.spring.annotations.Post;
 import org.androidannotations.rest.spring.annotations.Rest;
@@ -40,4 +41,7 @@ public interface ClientWithWrongFields {
 	void fieldAndEntity(@Field int v1, String entity);
 
 	void missingPostAnnotation(@Field("missingPost") int v1);
+
+	@Post("/fieldAndPartOnSameMethod")
+	void fieldAndPartOnSameMethod(@Field String field, @Part String part);
 }

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/ClientWithWrongPathVariables.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/ClientWithWrongPathVariables.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.rest.spring;
+
+import org.androidannotations.rest.spring.annotations.Get;
+import org.androidannotations.rest.spring.annotations.Path;
+import org.androidannotations.rest.spring.annotations.Rest;
+import org.springframework.http.converter.json.MappingJacksonHttpMessageConverter;
+
+@Rest(converters = MappingJacksonHttpMessageConverter.class)
+public interface ClientWithWrongPathVariables {
+
+	@Get("/duplicates/{v1}")
+	void getWithDuplicatePathVariables(@Path("v1") int v1, @Path("v1") int v2);
+
+	@Get("/missingvariable/{v1}")
+	void getWithMissingPathVariable(@Path("v1") int v1, @Path("v2") int hasMissingVariable);
+
+	@Get("/missingparameter/{v1}")
+	void getWithMissingMethodParameter(@Path("v1") int v1);
+
+	void missingGetAnnotation(@Path("missingGet") int v1);
+}

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/FieldPathParamOnSameArgument.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/FieldPathParamOnSameArgument.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.rest.spring;
+
+import org.androidannotations.rest.spring.annotations.Field;
+import org.androidannotations.rest.spring.annotations.Path;
+import org.androidannotations.rest.spring.annotations.Post;
+import org.androidannotations.rest.spring.annotations.Rest;
+import org.springframework.http.converter.FormHttpMessageConverter;
+
+@Rest(converters = FormHttpMessageConverter.class)
+public interface FieldPathParamOnSameArgument {
+
+	@Post("/fieldPathParamOnSameArgument")
+	void postParamPathParamOnSameArgument(@Field @Path int string);
+
+}

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/RestTest.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/RestTest.java
@@ -79,6 +79,16 @@ public class RestTest extends AAProcessorTestHelper {
 	}
 
 	@Test
+	public void clientWithWrongPathVariables() throws IOException {
+		CompileResult result = compileFiles(ClientWithWrongPathVariables.class);
+		assertCompilationErrorOn(ClientWithWrongPathVariables.class, "@Get(\"/duplicates/{v1}\")", result);
+		assertCompilationErrorOn(ClientWithWrongPathVariables.class, "@Get(\"/missingvariable/{v1}\")", result);
+		assertCompilationErrorOn(ClientWithWrongPathVariables.class, "@Path(\"v2\")", result);
+		assertCompilationErrorOn(ClientWithWrongPathVariables.class, "@Path(\"missingGet\")", result);
+		assertCompilationErrorCount(5, result);
+	}
+
+	@Test
 	public void clientWithWrongEnhancedMethods() throws IOException {
 		CompileResult result = compileFiles(ClientWithWrongEnhancedMethod.class);
 		assertCompilationErrorOn(ClientWithWrongEnhancedMethod.class, "Object getRestTemplate();", result);

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/RestTest.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/RestTest.java
@@ -107,8 +107,9 @@ public class RestTest extends AAProcessorTestHelper {
 		assertCompilationErrorOn(ClientWithWrongFields.class, "@Path(\"pathParamConflict\")", result);
 		assertCompilationErrorOn(ClientWithWrongFields.class, "@Post(\"/conflictWithPathParam\")", result);
 		assertCompilationErrorOn(ClientWithWrongFields.class, "@Post(\"/duplicateField\")", result);
+		assertCompilationErrorOn(ClientWithWrongFields.class, "@Post(\"/fieldAndPartOnSameMethod\")", result);
 
-		assertCompilationErrorCount(10, result);
+		assertCompilationErrorCount(11, result);
 	}
 
 	@Test

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/RestTest.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/RestTest.java
@@ -89,6 +89,44 @@ public class RestTest extends AAProcessorTestHelper {
 	}
 
 	@Test
+	public void clientWithPostParameters() throws IOException {
+		CompileResult result = compileFiles(ClientWithPostParameters.class);
+		assertCompilationSuccessful(result);
+	}
+
+	@Test
+	public void clientWithWrongPostParameters() throws IOException {
+		CompileResult result = compileFiles(ClientWithWrongFields.class);
+		assertCompilationErrorOn(ClientWithWrongFields.class, "void missingPostAnnotation(@Field(\"missingPost\") int v1);", result);
+		assertCompilationErrorOn(ClientWithWrongFields.class, "@Field(\"missingPost\")", result);
+		assertCompilationErrorOn(ClientWithWrongFields.class, "@Post(\"/pathParamAndEntity\")", result);
+		assertCompilationErrorOn(ClientWithWrongFields.class, "@Path(\"conflict\")", result);
+		assertCompilationErrorOn(ClientWithWrongFields.class, "@Post(\"/conflictElementNameWithPathParam\")", result);
+		assertCompilationErrorOn(ClientWithWrongFields.class, "@Post(\"/conflictWithPathParamWithElementName\")", result);
+		assertCompilationErrorOn(ClientWithWrongFields.class, "@Path(\"elementNameConflict\")", result);
+		assertCompilationErrorOn(ClientWithWrongFields.class, "@Path(\"pathParamConflict\")", result);
+		assertCompilationErrorOn(ClientWithWrongFields.class, "@Post(\"/conflictWithPathParam\")", result);
+		assertCompilationErrorOn(ClientWithWrongFields.class, "@Post(\"/duplicateField\")", result);
+
+		assertCompilationErrorCount(10, result);
+	}
+
+	@Test
+	public void fieldPathParamOnSameArgument() throws IOException {
+		CompileResult result = compileFiles(FieldPathParamOnSameArgument.class);
+		assertCompilationErrorOn(FieldPathParamOnSameArgument.class, "@Field", result);
+		assertCompilationErrorOn(FieldPathParamOnSameArgument.class, "@Path", result);
+
+		assertCompilationErrorCount(2, result);
+	}
+
+	@Test
+	public void clientWithMissingFormConverter() throws IOException {
+		CompileResult result = compileFiles(ClientWithMissingFormConverter.class);
+		assertCompilationErrorCount(1, result);
+	}
+
+	@Test
 	public void clientWithWrongEnhancedMethods() throws IOException {
 		CompileResult result = compileFiles(ClientWithWrongEnhancedMethod.class);
 		assertCompilationErrorOn(ClientWithWrongEnhancedMethod.class, "Object getRestTemplate();", result);


### PR DESCRIPTION
`@PathParam`: allows to add different url variable name than the method parameter name. It can be expanded later to use url encoding.

```java
@Post("/login{id}")
void login(User user, @Path("id") String identifier);
```

`@Field`: allows to add post parameters as method parameters, just like url variables. Form data and multipart data are supported.

```java
@Post("/login")
void login(@Field String username, @Field String password);
```

About multipart: currently, it requires some boilerplate, but much less than before:
```java
@Post("/profilepicture")
@RequiresHeader("Content-Type")
void upload(@Field String name, @Field FileResource picture);

userRestClient.setHeader("Content-Type", MULTIPART_FORM_DATA);
// normal calls
```
It would be better to remove the need for this.

* we could use #967, to add ```@Headers(@Header(headerName = "Content-Type", value = MULTIPART_FORM_DATA ))```
* create a `@Part` annotation which automatically adds the header, and works like `@Field`
* multi-part post flag for `@Post` which adds the header
* add the header if the parameter type is [`Resource`](http://docs.spring.io/spring-android/docs/2.0.0.M1/api/org/springframework/core/io/Resource.html)
* combination of them

I am open to any suggestions.

Implements #1438.