### PR TITLE
@FragmentByXXX inject child Fragments

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/FragmentById.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/FragmentById.java
@@ -42,7 +42,7 @@ import java.lang.annotation.Target;
  *     android:layout_height="match_parent" &gt;
  * 
  *     &lt;fragment
- *         android:id="@+id/myFragment"
+ *         android:id="@+id/<b>myFragment</b>"
  *         android:name="mypackage.MyFragment_"
  *         android:layout_width="match_parent"
  *         android:layout_height="match_parent" /&gt;
@@ -55,9 +55,9 @@ import java.lang.annotation.Target;
  * // all injected fragment will be the same
  * 
  * 	&#064;FragmentById
- * 	public MyFragment myFragment;
+ * 	public MyFragment <b>myFragment</b>;
  * 	
- * 	&#064;FragmentById(R.id.myFragment)
+ * 	&#064;FragmentById(R.id.<b>myFragment</b>)
  * 	public MyFragment myFragment2;
  * }
  * </pre>

--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/FragmentById.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/FragmentById.java
@@ -64,6 +64,43 @@ import java.lang.annotation.Target;
  * 
  * </blockquote>
  * 
+ * <p>
+ * To use the <code>getChildFragmentManager()</code> to inject the
+ * <code>Fragment</code>, set the {@link #childFragment()} annotation parameter
+ * to <code>true</code>. You can only do this if the annotated field is in a
+ * class which extends <code>android.app.Fragment</code> or
+ * <code>android.support.v4.app.Fragment</code> and the
+ * <code>getChildFragmentManager()</code> method is available.
+ * </p>
+ * 
+ * <blockquote>
+ * 
+ * Example :
+ * 
+ * <pre>
+ * &lt;LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+ *     android:layout_width="match_parent"
+ *     android:layout_height="match_parent" &gt;
+ * 
+ *     &lt;fragment
+ *         android:id="@+id/myChildFragment"
+ *         android:name="mypackage.MyChildFragment_"
+ *         android:layout_width="match_parent"
+ *         android:layout_height="match_parent" /&gt;
+ * &lt;/LinearLayout&gt;
+ * 
+ * 
+ * &#064;EFragment(R.layout.parentfragment)
+ * public class MyParentFragment extends Fragment {
+ * 
+ * 	&#064;FragmentById(<b>childFragment = true</b>)
+ * 	MyChildFragment myFragment;
+ * 
+ * }
+ * </pre>
+ * 
+ * </blockquote>
+ * 
  * @see EFragment
  * @see FragmentArg
  * @see FragmentByTag
@@ -85,4 +122,14 @@ public @interface FragmentById {
 	 * @return the resource name of the Fragment
 	 */
 	String resName() default "";
+
+	/**
+	 * Whether to use <code>getChildFragmentManager()</code> or
+	 * <code>getFragmentManager()</code> to obtain the Fragment. Only can be
+	 * <code>true</code> when injecting into a <code>Fragment</code>.
+	 * 
+	 * @return <code>true</code> to use <code>getChildFragmentManager()</code>,
+	 *         <code>false</code> to use <code>getFragmentManager()</code>
+	 */
+	boolean childFragment() default false;
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/FragmentByTag.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/FragmentByTag.java
@@ -43,7 +43,7 @@ import java.lang.annotation.Target;
  * 
  *     &lt;fragment
  *         android:id="@+id/myFragment"
- *         android:tag="myFragmentTag"
+ *         android:tag="<b>myFragmentTag</b>"
  *         android:name="mypackage.MyFragment_"
  *         android:layout_width="match_parent"
  *         android:layout_height="match_parent" /&gt;
@@ -56,16 +56,15 @@ import java.lang.annotation.Target;
  * // all injected fragment will be the same
  * 
  * 	&#064;FragmentByTag
- * 	public MyFragment myFragmentTag;
+ * 	public MyFragment <b>myFragmentTag</b>;
  * 	
- * 	&#064;FragmentByTag("myFragmentTag")
+ * 	&#064;FragmentByTag(<b>"myFragmentTag"</b>)
  * 	public MyFragment myFragmentTag2;
  * }
  * </pre>
  * 
  * </blockquote>
- * 
- * *
+ *
  * <p>
  * To use the <code>getChildFragmentManager()</code> to inject the
  * <code>Fragment</code>, set the {@link #childFragment()} annotation parameter

--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/FragmentByTag.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/FragmentByTag.java
@@ -65,6 +65,45 @@ import java.lang.annotation.Target;
  * 
  * </blockquote>
  * 
+ * *
+ * <p>
+ * To use the <code>getChildFragmentManager()</code> to inject the
+ * <code>Fragment</code>, set the {@link #childFragment()} annotation parameter
+ * to <code>true</code>. You can only do this if the annotated field is in a
+ * class which extends <code>android.app.Fragment</code> or
+ * <code>android.support.v4.app.Fragment</code> and the
+ * <code>getChildFragmentManager()</code> method is available.
+ * </p>
+ * 
+ * <blockquote>
+ * 
+ * Example :
+ * 
+ * <pre>
+ * &lt;LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+ *     android:layout_width="match_parent"
+ *     android:layout_height="match_parent" &gt;
+ * 
+ *     &lt;fragment
+ *         android:id="@+id/myChildFragment"
+ *         android:tag="myChildFragment"
+ *         android:name="mypackage.MyChildFragment_"
+ *         android:layout_width="match_parent"
+ *         android:layout_height="match_parent" /&gt;
+ * &lt;/LinearLayout&gt;
+ * 
+ * 
+ * &#064;EFragment(R.layout.parentfragment)
+ * public class MyParentFragment extends Fragment {
+ * 
+ * 	&#064;FragmentByTag(<b>childFragment = true</b>)
+ * 	MyChildFragment myFragment;
+ * 
+ * }
+ * </pre>
+ * 
+ * </blockquote>
+ * 
  * @see EFragment
  * @see FragmentArg
  * @see FragmentById
@@ -79,4 +118,14 @@ public @interface FragmentByTag {
 	 * @return the tag of the Fragment
 	 */
 	String value() default "";
+
+	/**
+	 * Whether to use <code>getChildFragmentManager()</code> or
+	 * <code>getFragmentManager()</code> to obtain the Fragment. Only can be
+	 * <code>true</code> when injecting into a <code>Fragment</code>.
+	 * 
+	 * @return <code>true</code> to use <code>getChildFragmentManager()</code>,
+	 *         <code>false</code> to use <code>getFragmentManager()</code>
+	 */
+	boolean childFragment() default false;
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/AbstractFragmentByHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/AbstractFragmentByHandler.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.internal.core.handler;
+
+import static com.sun.codemodel.JExpr.cast;
+import static com.sun.codemodel.JExpr.invoke;
+import static com.sun.codemodel.JExpr.ref;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+
+import org.androidannotations.AndroidAnnotationsEnvironment;
+import org.androidannotations.ElementValidation;
+import org.androidannotations.handler.BaseAnnotationHandler;
+import org.androidannotations.helper.CanonicalNameConstants;
+import org.androidannotations.holder.EComponentWithViewSupportHolder;
+
+import com.sun.codemodel.JBlock;
+import com.sun.codemodel.JExpression;
+import com.sun.codemodel.JMethod;
+
+public abstract class AbstractFragmentByHandler extends BaseAnnotationHandler<EComponentWithViewSupportHolder> {
+
+	public AbstractFragmentByHandler(Class<?> targetClass, AndroidAnnotationsEnvironment environment) {
+		super(targetClass, environment);
+	}
+
+	@Override
+	protected void validate(Element element, ElementValidation validation) {
+		validatorHelper.enclosingElementHasEnhancedViewSupportAnnotation(element, validation);
+
+		validatorHelper.extendsFragment(element, validation);
+
+		validatorHelper.isNotPrivate(element, validation);
+	}
+
+	@Override
+	public final void process(Element element, EComponentWithViewSupportHolder holder) throws Exception {
+		TypeMirror elementType = element.asType();
+		String typeQualifiedName = elementType.toString();
+		TypeElement nativeFragmentElement = annotationHelper.typeElementFromQualifiedName(CanonicalNameConstants.FRAGMENT);
+		boolean isNativeFragment = nativeFragmentElement != null && annotationHelper.isSubtype(elementType, nativeFragmentElement.asType());
+
+		JMethod findFragmentMethod = getFindFragmentMethod(isNativeFragment, holder);
+
+		String fieldName = element.getSimpleName().toString();
+		JBlock methodBody = holder.getOnViewChangedBody();
+
+		methodBody.assign(ref(fieldName), cast(getJClass(typeQualifiedName), invoke(findFragmentMethod).arg(getFragmentId(element, fieldName))));
+	}
+
+	protected abstract JMethod getFindFragmentMethod(boolean isNativeFragment, EComponentWithViewSupportHolder holder);
+
+	protected abstract JExpression getFragmentId(Element element, String fieldName);
+
+}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/FragmentByIdHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/FragmentByIdHandler.java
@@ -30,7 +30,7 @@ import com.sun.codemodel.JMethod;
 public class FragmentByIdHandler extends AbstractFragmentByHandler {
 
 	public FragmentByIdHandler(AndroidAnnotationsEnvironment environment) {
-		super(FragmentById.class, environment);
+		super(FragmentById.class, environment, "findFragmentById");
 	}
 
 	@Override

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/FragmentByIdHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/FragmentByIdHandler.java
@@ -15,28 +15,19 @@
  */
 package org.androidannotations.internal.core.handler;
 
-import static com.sun.codemodel.JExpr.cast;
-import static com.sun.codemodel.JExpr.invoke;
-import static com.sun.codemodel.JExpr.ref;
-
 import javax.lang.model.element.Element;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.TypeMirror;
 
 import org.androidannotations.AndroidAnnotationsEnvironment;
 import org.androidannotations.ElementValidation;
 import org.androidannotations.annotations.FragmentById;
-import org.androidannotations.handler.BaseAnnotationHandler;
-import org.androidannotations.helper.CanonicalNameConstants;
 import org.androidannotations.helper.IdValidatorHelper;
 import org.androidannotations.holder.EComponentWithViewSupportHolder;
 import org.androidannotations.rclass.IRClass;
 
-import com.sun.codemodel.JBlock;
-import com.sun.codemodel.JFieldRef;
+import com.sun.codemodel.JExpression;
 import com.sun.codemodel.JMethod;
 
-public class FragmentByIdHandler extends BaseAnnotationHandler<EComponentWithViewSupportHolder> {
+public class FragmentByIdHandler extends AbstractFragmentByHandler {
 
 	public FragmentByIdHandler(AndroidAnnotationsEnvironment environment) {
 		super(FragmentById.class, environment);
@@ -44,37 +35,18 @@ public class FragmentByIdHandler extends BaseAnnotationHandler<EComponentWithVie
 
 	@Override
 	public void validate(Element element, ElementValidation validation) {
-		validatorHelper.enclosingElementHasEnhancedViewSupportAnnotation(element,  validation);
-
-		validatorHelper.extendsFragment(element, validation);
+		super.validate(element, validation);
 
 		validatorHelper.resIdsExist(element, IRClass.Res.ID, IdValidatorHelper.FallbackStrategy.USE_ELEMENT_NAME, validation);
-
-		validatorHelper.isNotPrivate(element, validation);
 	}
 
 	@Override
-	public void process(Element element, EComponentWithViewSupportHolder holder) {
+	protected JMethod getFindFragmentMethod(boolean isNativeFragment, EComponentWithViewSupportHolder holder) {
+		return isNativeFragment ? holder.getFindNativeFragmentById() : holder.getFindSupportFragmentById();
+	}
 
-		TypeMirror elementType = element.asType();
-		String typeQualifiedName = elementType.toString();
-		TypeElement nativeFragmentElement = annotationHelper.typeElementFromQualifiedName(CanonicalNameConstants.FRAGMENT);
-		boolean isNativeFragment = nativeFragmentElement != null && annotationHelper.isSubtype(elementType, nativeFragmentElement.asType());
-
-		JMethod findFragmentById;
-		if (isNativeFragment) {
-			findFragmentById = holder.getFindNativeFragmentById();
-		} else {
-			findFragmentById = holder.getFindSupportFragmentById();
-		}
-
-		String fieldName = element.getSimpleName().toString();
-
-		JFieldRef idRef = annotationHelper.extractOneAnnotationFieldRef(element, IRClass.Res.ID, true);
-
-		JBlock methodBody = holder.getOnViewChangedBody();
-
-		methodBody.assign(ref(fieldName), cast(getJClass(typeQualifiedName), invoke(findFragmentById).arg(idRef)));
-
+	@Override
+	protected JExpression getFragmentId(Element element, String fieldName) {
+		return annotationHelper.extractOneAnnotationFieldRef(element, IRClass.Res.ID, true);
 	}
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/FragmentByTagHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/FragmentByTagHandler.java
@@ -15,62 +15,35 @@
  */
 package org.androidannotations.internal.core.handler;
 
-import static com.sun.codemodel.JExpr.cast;
-import static com.sun.codemodel.JExpr.invoke;
 import static com.sun.codemodel.JExpr.lit;
-import static com.sun.codemodel.JExpr.ref;
 
 import javax.lang.model.element.Element;
-import javax.lang.model.type.TypeMirror;
 
 import org.androidannotations.AndroidAnnotationsEnvironment;
-import org.androidannotations.ElementValidation;
 import org.androidannotations.annotations.FragmentByTag;
-import org.androidannotations.handler.BaseAnnotationHandler;
-import org.androidannotations.helper.CanonicalNameConstants;
 import org.androidannotations.holder.EComponentWithViewSupportHolder;
 
-import com.sun.codemodel.JBlock;
+import com.sun.codemodel.JExpression;
 import com.sun.codemodel.JMethod;
 
-public class FragmentByTagHandler extends BaseAnnotationHandler<EComponentWithViewSupportHolder> {
+public class FragmentByTagHandler extends AbstractFragmentByHandler {
 
 	public FragmentByTagHandler(AndroidAnnotationsEnvironment environment) {
 		super(FragmentByTag.class, environment);
 	}
 
 	@Override
-	public void validate(Element element, ElementValidation validation) {
-		validatorHelper.enclosingElementHasEnhancedViewSupportAnnotation(element,  validation);
-
-		validatorHelper.extendsFragment(element, validation);
-
-		validatorHelper.isNotPrivate(element, validation);
+	protected JMethod getFindFragmentMethod(boolean isNativeFragment, EComponentWithViewSupportHolder holder) {
+		return isNativeFragment ? holder.getFindNativeFragmentByTag() : holder.getFindSupportFragmentByTag();
 	}
 
 	@Override
-	public void process(Element element, EComponentWithViewSupportHolder holder) {
-
-		TypeMirror elementType = element.asType();
-		String typeQualifiedName = elementType.toString();
-		TypeMirror nativeFragmentType = annotationHelper.typeElementFromQualifiedName(CanonicalNameConstants.FRAGMENT).asType();
-		boolean isNativeFragment = annotationHelper.isSubtype(elementType, nativeFragmentType);
-
-		JMethod findFragmentByTag;
-		if (isNativeFragment) {
-			findFragmentByTag = holder.getFindNativeFragmentByTag();
-		} else {
-			findFragmentByTag = holder.getFindSupportFragmentByTag();
-		}
-
-		String fieldName = element.getSimpleName().toString();
+	protected JExpression getFragmentId(Element element, String fieldName) {
 		FragmentByTag annotation = element.getAnnotation(FragmentByTag.class);
 		String tagValue = annotation.value();
 		if (tagValue.equals("")) {
 			tagValue = fieldName;
 		}
-
-		JBlock methodBody = holder.getOnViewChangedBody();
-		methodBody.assign(ref(fieldName), cast(getJClass(typeQualifiedName), invoke(findFragmentByTag).arg(lit(tagValue))));
+		return lit(tagValue);
 	}
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/FragmentByTagHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/FragmentByTagHandler.java
@@ -29,7 +29,7 @@ import com.sun.codemodel.JMethod;
 public class FragmentByTagHandler extends AbstractFragmentByHandler {
 
 	public FragmentByTagHandler(AndroidAnnotationsEnvironment environment) {
-		super(FragmentByTag.class, environment);
+		super(FragmentByTag.class, environment, "findFragmentByTag");
 	}
 
 	@Override

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/generation/ActivityWithChildFragment.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/generation/ActivityWithChildFragment.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.generation;
+
+import org.androidannotations.annotations.EActivity;
+import org.androidannotations.annotations.FragmentByTag;
+
+import android.app.Activity;
+import android.app.Fragment;
+
+@EActivity
+public class ActivityWithChildFragment extends Activity {
+
+	@FragmentByTag(childFragment = true)
+	Fragment child;
+}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/generation/FragmentByChildFragmentManagerTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/generation/FragmentByChildFragmentManagerTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.generation;
+
+import java.io.IOException;
+
+import org.androidannotations.internal.AndroidAnnotationProcessor;
+import org.androidannotations.testutils.AAProcessorTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FragmentByChildFragmentManagerTest extends AAProcessorTestHelper {
+
+	@Before
+	public void setUp() {
+		addProcessor(AndroidAnnotationProcessor.class);
+	}
+
+	@Test
+	public void nativeFragmentByIdChildFragmentDoesNotCompileWithWithFroyo() throws IOException {
+		addManifestProcessorParameter(FragmentByChildFragmentManagerTest.class, "AndroidManifestMinFroyo.xml");
+
+		CompileResult result = compileFiles(toPath(FragmentByChildFragmentManagerTest.class, "Fragment.java"), NativeFragmentWithChild.class);
+
+		assertCompilationErrorOn(NativeFragmentWithChild.class, "@FragmentByTag(childFragment = true)", result);
+		assertCompilationErrorCount(1, result);
+	}
+
+	@Test
+	public void nativeFragmentByIdChildFragmentCompilesWithWithJB() {
+		addManifestProcessorParameter(FragmentByChildFragmentManagerTest.class, "AndroidManifestMinJB.xml");
+
+		CompileResult result = compileFiles(toPath(FragmentByChildFragmentManagerTest.class, "Fragment.java"), NativeFragmentWithChild.class);
+
+		assertCompilationSuccessful(result);
+	}
+
+	@Test
+	public void nativeFragmentByIdChildFragmentDoesNotCompileInActivity() throws IOException {
+		addManifestProcessorParameter(FragmentByChildFragmentManagerTest.class, "AndroidManifestMinJB.xml");
+
+		CompileResult result = compileFiles(toPath(FragmentByChildFragmentManagerTest.class, "Fragment.java"), ActivityWithChildFragment.class);
+
+		assertCompilationErrorOn(ActivityWithChildFragment.class, "@FragmentByTag(childFragment = true)", result);
+		assertCompilationErrorCount(1, result);
+	}
+
+	@Test
+	public void supportFragmentByIdChildFragmentCompilesWhenFragmentHasGetChildFragmentManager() {
+		addManifestProcessorParameter(FragmentByChildFragmentManagerTest.class, "AndroidManifestMinJB.xml");
+
+		CompileResult result = compileFiles(toPath(FragmentByChildFragmentManagerTest.class, "support/Fragment.java"), //
+				toPath(FragmentByChildFragmentManagerTest.class, "SupportFragmentWithChild.java"));
+
+		assertCompilationSuccessful(result);
+	}
+
+	@Test
+	public void supportFragmentByIdChildFragmentDoesNotCompileWhenFragmentDoesNotHaveGetChildFragmentManager() throws ClassNotFoundException, IOException {
+		addManifestProcessorParameter(FragmentByChildFragmentManagerTest.class, "AndroidManifestMinJB.xml");
+
+		CompileResult result = compileFiles(toPath(FragmentByChildFragmentManagerTest.class, "support/old/Fragment.java"), //
+				toPath(FragmentByChildFragmentManagerTest.class, "SupportFragmentWithChild.java"));
+
+		assertCompilationErrorOn("SupportFragmentWithChild", "@FragmentByTag", result);
+		assertCompilationErrorCount(1, result);
+	}
+}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/generation/NativeFragmentWithChild.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/generation/NativeFragmentWithChild.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.generation;
+
+import org.androidannotations.annotations.EFragment;
+import org.androidannotations.annotations.FragmentByTag;
+
+import android.app.Fragment;
+
+@EFragment
+public class NativeFragmentWithChild extends Fragment {
+
+	@FragmentByTag(childFragment = true)
+	Fragment child;
+}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/resources/org/androidannotations/generation/SupportFragmentWithChild.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/resources/org/androidannotations/generation/SupportFragmentWithChild.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.generation;
+
+import org.androidannotations.annotations.EFragment;
+import org.androidannotations.annotations.FragmentByTag;
+
+import android.support.v4.app.Fragment;
+
+@EFragment
+public class SupportFragmentWithChild extends Fragment {
+
+	@FragmentByTag(childFragment = true)
+	Fragment child;
+}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/resources/org/androidannotations/generation/support/Fragment.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/resources/org/androidannotations/generation/support/Fragment.java
@@ -23,6 +23,26 @@ import android.content.Intent;
  * classpath only on some unit tests methods
  */
 public class Fragment {
+	
+	public void onCreate(android.os.Bundle savedInstanceState) {
+		
+	}
+	
+	public void onViewCreated(android.view.View view, android.os.Bundle savedInstanceState) {
+		
+	}
+	
+	public android.view.View onCreateView(android.view.LayoutInflater inflater, android.view.ViewGroup container, android.os.Bundle savedInstanceState) {
+		return null;
+	}
+	
+	public  void onDestroyView() {
+		
+	}
+	
+	public  void setArguments(android.os.Bundle args) {
+		
+	}
 
 	public Activity getActivity() {
 		return null;
@@ -30,6 +50,21 @@ public class Fragment {
 
 	public void startActivityForResult(Intent intent, int flag) {
 
+	}
+	
+	public FragmentManager getFragmentManager() {
+		return null;
+	}
+	
+	public FragmentManager getChildFragmentManager() {
+		return null;
+	}
+
+	public abstract class FragmentManager {
+		
+		public abstract Fragment findFragmentById(int id);
+		
+		public abstract Fragment findFragmentByTag(String tag);
 	}
 
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/resources/org/androidannotations/generation/support/old/Fragment.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/resources/org/androidannotations/generation/support/old/Fragment.java
@@ -13,14 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package android.app;
+package android.support.v4.app;
 
+import android.app.Activity;
 import android.content.Intent;
 
-/**
- * We have to put this on resources folder because we want to add it to
- * classpath only on some unit tests methods
- */
 public class Fragment {
 
 	public void onCreate(android.os.Bundle savedInstanceState) {
@@ -49,21 +46,6 @@ public class Fragment {
 
 	public void startActivityForResult(Intent intent, int flag) {
 
-	}
-	
-	public FragmentManager getFragmentManager() {
-		return null;
-	}
-	
-	public FragmentManager getChildFragmentManager() {
-		return null;
-	}
-
-	public abstract class FragmentManager {
-		
-		public abstract Fragment findFragmentById(int id);
-		
-		public abstract Fragment findFragmentByTag(String tag);
 	}
 
 }


### PR DESCRIPTION
Implements #1302.

This is a breaking change, because `@EFragment`s now always use `getFragmentManager()` instead of `getActivity().getFragmentManager()` (or `getChildFragmentManager()` but only if that is set).