### PR TITLE
Use ParameterizedTypeReference in REST method calls

### DIFF
--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/helper/RestSpringClasses.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/helper/RestSpringClasses.java
@@ -30,6 +30,7 @@ public final class RestSpringClasses {
 	public static final String HTTP_BASIC_AUTHENTICATION = "org.springframework.http.HttpBasicAuthentication";
 	public static final String REST_CLIENT_EXCEPTION = "org.springframework.web.client.RestClientException";
 	public static final String NESTED_RUNTIME_EXCEPTION = "org.springframework.core.NestedRuntimeException";
+	public static final String PARAMETERIZED_TYPE_REFERENCE = "org.springframework.core.ParameterizedTypeReference";
 
 	private RestSpringClasses() {
 


### PR DESCRIPTION
Generic response class is natively supported in Spring for Android 2.0. This change utilizes that support, if it is available and the reponse class is generic. It falls back to the old implementation otherwise.

Unfortunetaly there is no way to add this to the compile or functional tests.

Related to #1440.