### PR TITLE
Allow to provide a default value for @DefaultStringSet

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/sharedpreferences/DefaultStringSet.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/sharedpreferences/DefaultStringSet.java
@@ -51,6 +51,13 @@ import org.androidannotations.annotations.ResId;
 public @interface DefaultStringSet {
 
 	/**
+	 * The default value of the preference.
+	 *
+	 * @return the default value
+	 */
+	String[] value();
+
+	/**
 	 * The R.string.* field which refers to the key of the preference.
 	 * 
 	 * @return the resource name of the preference key

--- a/AndroidAnnotations/androidannotations-core/androidannotations-test/src/main/java/org/androidannotations/test/prefs/SomePrefs.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-test/src/main/java/org/androidannotations/test/prefs/SomePrefs.java
@@ -22,6 +22,7 @@ import org.androidannotations.annotations.sharedpreferences.DefaultFloat;
 import org.androidannotations.annotations.sharedpreferences.DefaultInt;
 import org.androidannotations.annotations.sharedpreferences.DefaultLong;
 import org.androidannotations.annotations.sharedpreferences.DefaultString;
+import org.androidannotations.annotations.sharedpreferences.DefaultStringSet;
 import org.androidannotations.annotations.sharedpreferences.SharedPref;
 import org.androidannotations.annotations.sharedpreferences.SharedPref.Scope;
 import org.androidannotations.test.R;
@@ -50,4 +51,7 @@ public interface SomePrefs {
 	long lastUpdated();
 
 	Set<String> types();
+
+	@DefaultStringSet({"a", "b", "c"})
+	Set<String> setWithDefault();
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations-test/src/test/java/org/androidannotations/test/prefs/PrefsActivityTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-test/src/test/java/org/androidannotations/test/prefs/PrefsActivityTest.java
@@ -18,6 +18,7 @@ package org.androidannotations.test.prefs;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -85,6 +86,12 @@ public class PrefsActivityTest {
 		Set<String> values = new TreeSet<String>(Arrays.asList("1", "2", "3"));
 		somePrefs.types().put(values);
 		assertThat(sharedPref.getStringSet("types", null)).isEqualTo(values);
+	}
+
+	@Test
+	public void checkSetDefaultValues() {
+		Set<String> values = new HashSet<String>(Arrays.asList("a", "b", "c"));
+		assertThat(somePrefs.setWithDefault().get()).isEqualTo(values);
 	}
 
 	@Test


### PR DESCRIPTION
based on https://github.com/excilys/androidannotations/pull/1553

This PR allows to provide a default value for a `@DefaultStringSet` annotated method in a `@SharedPref` interface.

Usage:
```java
	@DefaultStringSet({"a", "b", "c"})
	Set<String> setWithDefault();
```

That generates:
```java
   public StringSetPrefField setWithDefault() {
        return stringSetField("setWithDefault", new HashSet<String>(Arrays.asList("a", "b", "c")));
    }
```