### PR TITLE
Added parceler `@Extra` and `@InstanceState` support

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/Extra.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/Extra.java
@@ -24,7 +24,11 @@ import java.lang.annotation.Target;
  * <p>
  * Use on any native, {@link android.os.Parcelable Parcelable} or
  * {@link java.io.Serializable Serializable} field in an {@link EActivity}
- * annotated class to bind it with Android's extra.
+ * annotated class to bind it with Android's arguments.
+ * If <a href="http://parceler.org">Parceler</a> is on the classpath, extras
+ * annotated with &#064;Parcel, or collections supported by Parceler will be
+ * automatically marshaled using a {@link android.os.Parcelable Parcelable}
+ * through the Parcels utility class.
  * </p>
  * <p>
  * The annotation value is the key used for extra. If not set, the field name
@@ -43,7 +47,7 @@ import java.lang.annotation.Target;
  * Activity#setIntent(Intent)} will automatically update the annotated extras.
  * </p>
  * <blockquote>
- * 
+ *
  * Example :
  * 
  * <pre>

--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/FragmentArg.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/FragmentArg.java
@@ -25,6 +25,10 @@ import java.lang.annotation.Target;
  * Use on any native, {@link android.os.Parcelable Parcelable} or
  * {@link java.io.Serializable Serializable} field in an {@link EFragment}
  * annotated class to bind it with Android's arguments.
+ * If <a href="http://parceler.org">Parceler</a> is on the classpath, extras
+ * annotated with &#064;Parcel, or collections supported by Parceler will be
+ * automatically marshaled using a {@link android.os.Parcelable Parcelable}
+ * through the Parcels utility class.
  * </p>
  * <p>
  * The annotation value is the key used for argument. If not set, the field name

--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/InstanceState.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/InstanceState.java
@@ -25,6 +25,15 @@ import java.lang.annotation.Target;
  * Use on activity fields to save and restore their values when the system calls
  * <code>onSaveInstanceState(Bundle)</code> and <code>onCreate(Bundle)</code>.
  * </p>
+ * <p>
+ * Use on any native, {@link android.os.Parcelable Parcelable} or
+ * {@link java.io.Serializable Serializable} field in an {@link EActivity}
+ * annotated class to bind it with Android's arguments.
+ * If <a href="http://parceler.org">Parceler</a> is on the classpath, extras
+ * annotated with &#064;Parcel, or collections supported by Parceler will be
+ * automatically marshaled using a {@link android.os.Parcelable Parcelable}
+ * through the Parcels utility class.
+ * </p>
  *
  * <blockquote>
  * 

--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/OnActivityResult.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/OnActivityResult.java
@@ -90,6 +90,10 @@ public @interface OnActivityResult {
 	 * Use on any native, {@link android.os.Parcelable} or
 	 * {@link java.io.Serializable} parameter of an {@link OnActivityResult}
 	 * annotated method to bind it with the value from the Intent.
+	 * If <a href="http://parceler.org">Parceler</a> is on the classpath, extras
+	 * annotated with &#064;Parcel, or collections supported by Parceler will be
+	 * automatically marshaled using a {@link android.os.Parcelable Parcelable}
+	 * through the Parcels utility class.
 	 * </p>
 	 * <p>
 	 * The annotation value is the key used for the result data. If not set, the

--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/Receiver.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/Receiver.java
@@ -155,6 +155,10 @@ public @interface Receiver {
 	 * {@code void onReceive(Context context, Intent intent)}. The key of this
 	 * extra is the value of the annotation {@link ReceiverAction.Extra} if it
 	 * is set or the name of the parameter.
+	 * If <a href="http://parceler.org">Parceler</a> is on the classpath, extras
+	 * annotated with &#064;Parcel, or collections supported by Parceler will be
+	 * automatically marshaled using a {@link android.os.Parcelable Parcelable}
+	 * through the Parcels utility class.
 	 * </p>
 	 */
 	@Retention(RetentionPolicy.CLASS)

--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/ReceiverAction.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/ReceiverAction.java
@@ -115,6 +115,10 @@ public @interface ReceiverAction {
 	 * {@code void onReceive(Context context, Intent intent)}. The key of this
 	 * extra is the value of the annotation {@link ReceiverAction.Extra} if it
 	 * is set or the name of the parameter.
+	 * If <a href="http://parceler.org">Parceler</a> is on the classpath, extras
+	 * annotated with &#064;Parcel, or collections supported by Parceler will be
+	 * automatically marshaled using a {@link android.os.Parcelable Parcelable}
+	 * through the Parcels utility class.
 	 * </p>
 	 */
 	@Retention(RetentionPolicy.CLASS)

--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/ServiceAction.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/ServiceAction.java
@@ -84,6 +84,15 @@ import java.lang.annotation.Target;
  * AbstractIntentService} class, which implements that method, so you do not
  * have to do in your actual class if you derive it.
  * </p>
+ * <p>
+ * Use on any native, {@link android.os.Parcelable Parcelable} or
+ * {@link java.io.Serializable Serializable} field in an {@link EService}
+ * annotated class to bind it with Android's arguments.
+ * If <a href="http://parceler.org">Parceler</a> is on the classpath, extras
+ * annotated with &#064;Parcel, or collections supported by Parceler will be
+ * automatically marshaled using a {@link android.os.Parcelable Parcelable}
+ * through the Parcels utility class.
+ * </p>
  * 
  * @see EIntentService
  * @see org.androidannotations.api.support.app.AbstractIntentService

--- a/AndroidAnnotations/androidannotations-core/androidannotations-test/pom.xml
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-test/pom.xml
@@ -82,6 +82,17 @@
 			<version>140</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.parceler</groupId>
+			<artifactId>parceler</artifactId>
+			<version>1.0.3</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.parceler</groupId>
+			<artifactId>parceler-api</artifactId>
+			<version>1.0.3</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/AndroidAnnotations/androidannotations-core/androidannotations-test/pom.xml
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-test/pom.xml
@@ -33,6 +33,7 @@
 		<main.basedir>${project.parent.parent.basedir}</main.basedir>
 		<android-rome-version>1.0.0-r2</android-rome-version>
 		<checkstyle.excludes>**/R.java,**/BuildConfig.java,</checkstyle.excludes>
+		<parceler.version>1.0.3</parceler.version>
 	</properties>
 
 	<dependencies>
@@ -85,13 +86,13 @@
 		<dependency>
 			<groupId>org.parceler</groupId>
 			<artifactId>parceler</artifactId>
-			<version>1.0.3</version>
+			<version>${parceler.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.parceler</groupId>
 			<artifactId>parceler-api</artifactId>
-			<version>1.0.3</version>
+			<version>${parceler.version}</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/AndroidAnnotations/androidannotations-core/androidannotations-test/src/main/java/org/androidannotations/test/ExtraInjectedActivity.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-test/src/main/java/org/androidannotations/test/ExtraInjectedActivity.java
@@ -16,9 +16,11 @@
 package org.androidannotations.test;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.androidannotations.annotations.EActivity;
 import org.androidannotations.annotations.Extra;
+import org.androidannotations.test.parceler.ParcelerBean;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -41,6 +43,12 @@ public class ExtraInjectedActivity extends Activity {
 	@Extra("byteArrayExtra")
 	byte[] byteArrayExtra;
 
+	@Extra("parcelerExtra")
+	ParcelerBean parcelerExample;
+
+	@Extra("parcelerExtraCollection")
+	List<ParcelerBean> parcelerExampleCollection;
+
 	@Extra
 	String extraWithoutValue;
 
@@ -57,6 +65,12 @@ public class ExtraInjectedActivity extends Activity {
 		ExtraInjectedActivity_.intent(this).intExtra(42).get();
 		ExtraInjectedActivity_.intent(this).stringExtra("hello")
 				.startForResult(42);
+		ExtraInjectedActivity_.intent(this)
+				.parcelerExample(new ParcelerBean("Andy", 42));
+		List<ParcelerBean> parcelerBeans = new ArrayList<ParcelerBean>();
+		parcelerBeans.add(new ParcelerBean("Duke", 1337));
+		ExtraInjectedActivity_.intent(this)
+				.parcelerExampleCollection(parcelerBeans);
 		ExtraInjectedActivity_.intent(this)
 				.parcelableSerializableData(new ParcelableSerializableData())
 				.get();

--- a/AndroidAnnotations/androidannotations-core/androidannotations-test/src/main/java/org/androidannotations/test/instancestate/SaveInstanceStateActivity.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-test/src/main/java/org/androidannotations/test/instancestate/SaveInstanceStateActivity.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import org.androidannotations.annotations.EActivity;
 import org.androidannotations.annotations.InstanceState;
 import org.androidannotations.test.R;
+import org.androidannotations.test.parceler.ParcelerBean;
 
 import android.app.Activity;
 import android.os.Bundle;
@@ -180,4 +181,6 @@ public class SaveInstanceStateActivity extends Activity {
 	@InstanceState
 	Bundle bundle;
 
+	@InstanceState
+	ParcelerBean parcelerBean;
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations-test/src/main/java/org/androidannotations/test/parceler/ParcelerBean.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-test/src/main/java/org/androidannotations/test/parceler/ParcelerBean.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test.parceler;
+
+import org.parceler.Parcel;
+import org.parceler.ParcelConstructor;
+
+
+@Parcel
+public class ParcelerBean {
+
+	String name;
+	int age;
+
+	public ParcelerBean() {
+	}
+
+	@ParcelConstructor
+	public ParcelerBean(String name, int age) {
+		this.name = name;
+		this.age = age;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public int getAge() {
+		return age;
+	}
+}

--- a/AndroidAnnotations/androidannotations-core/androidannotations-test/src/test/java/org/androidannotations/test/InjectExtraTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-test/src/test/java/org/androidannotations/test/InjectExtraTest.java
@@ -18,7 +18,9 @@ package org.androidannotations.test;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 import java.util.ArrayList;
+import java.util.List;
 
+import org.androidannotations.test.parceler.ParcelerBean;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -91,6 +93,24 @@ public class InjectExtraTest {
 	public void extraWithoutValueInjected() {
 		controller.withIntent(ExtraInjectedActivity_.intent(context).extraWithoutValue("Hello!").get()).create();
 		assertThat(activity.extraWithoutValue).isEqualTo("Hello!");
+	}
+
+	@Test
+	public void parcelerExtraInjected() {
+		controller.withIntent(ExtraInjectedActivity_.intent(context).parcelerExample(new ParcelerBean("Andy", 42)).get()).create();
+		assertThat(activity.parcelerExample.getName()).isEqualTo("Andy");
+		assertThat(activity.parcelerExample.getAge()).isEqualTo(42);
+	}
+
+	@Test
+	public void parcelerExtraCollectionInjected() {
+		List<ParcelerBean> parcelerBeans = new ArrayList<ParcelerBean>();
+		parcelerBeans.add(new ParcelerBean("Duke", 1337));
+		controller.withIntent(ExtraInjectedActivity_.intent(context).parcelerExampleCollection(parcelerBeans).get()).create();
+		assertThat(activity.parcelerExampleCollection.size()).isEqualTo(1);
+		ParcelerBean bean = activity.parcelerExampleCollection.iterator().next();
+		assertThat(bean.getName()).isEqualTo("Duke");
+		assertThat(bean.getAge()).isEqualTo(1337);
 	}
 
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/AnnotationHelper.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/AnnotationHelper.java
@@ -22,19 +22,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.SortedSet;
-import java.util.TreeMap;
-import java.util.TreeSet;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
@@ -66,40 +55,6 @@ public class AnnotationHelper {
 
 	public static final String DEFAULT_FIELD_NAME_VALUE = "value";
 	public static final String DEFAULT_FIELD_NAME_RESNAME = "resName";
-	private static final String PARCEL_ANNOTATION = "org.parceler.Parcel";
-	private static final Map<String, Integer> SUPPORTED_PARCEL_TYPES = new HashMap<>();
-
-	static {
-		SUPPORTED_PARCEL_TYPES.put(Collection.class.getName(), 1);
-		SUPPORTED_PARCEL_TYPES.put(List.class.getName(), 1);
-		SUPPORTED_PARCEL_TYPES.put(ArrayList.class.getName(), 1);
-		SUPPORTED_PARCEL_TYPES.put(Set.class.getName(), 1);
-		SUPPORTED_PARCEL_TYPES.put(HashSet.class.getName(), 2);
-		SUPPORTED_PARCEL_TYPES.put(TreeSet.class.getName(), 2);
-		SUPPORTED_PARCEL_TYPES.put(CanonicalNameConstants.SPARSE_ARRAY, 1);
-		SUPPORTED_PARCEL_TYPES.put(Map.class.getName(), 2);
-		SUPPORTED_PARCEL_TYPES.put(HashMap.class.getName(), 2);
-		SUPPORTED_PARCEL_TYPES.put(TreeMap.class.getName(), 2);
-		SUPPORTED_PARCEL_TYPES.put(Integer.class.getName(), 0);
-		SUPPORTED_PARCEL_TYPES.put(Long.class.getName(), 0);
-		SUPPORTED_PARCEL_TYPES.put(Double.class.getName(), 0);
-		SUPPORTED_PARCEL_TYPES.put(Float.class.getName(), 0);
-		SUPPORTED_PARCEL_TYPES.put(Byte.class.getName(), 0);
-		SUPPORTED_PARCEL_TYPES.put(String.class.getName(), 0);
-		SUPPORTED_PARCEL_TYPES.put(Character.class.getName(), 0);
-		SUPPORTED_PARCEL_TYPES.put(Boolean.class.getName(), 0);
-		SUPPORTED_PARCEL_TYPES.put(byte[].class.getName(), 0);
-		SUPPORTED_PARCEL_TYPES.put(char[].class.getName(), 0);
-		SUPPORTED_PARCEL_TYPES.put(boolean[].class.getName(), 0);
-		SUPPORTED_PARCEL_TYPES.put(CanonicalNameConstants.IBINDER, 0);
-		SUPPORTED_PARCEL_TYPES.put(CanonicalNameConstants.BUNDLE, 0);
-		SUPPORTED_PARCEL_TYPES.put(CanonicalNameConstants.SPARSE_BOOLEAN_ARRAY, 0);
-		SUPPORTED_PARCEL_TYPES.put(LinkedList.class.getName(), 1);
-		SUPPORTED_PARCEL_TYPES.put(LinkedHashMap.class.getName(), 2);
-		SUPPORTED_PARCEL_TYPES.put(SortedMap.class.getName(), 2);
-		SUPPORTED_PARCEL_TYPES.put(SortedSet.class.getName(), 1);
-		SUPPORTED_PARCEL_TYPES.put(LinkedHashSet.class.getName(), 1);
-	};
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(AnnotationHelper.class);
 
@@ -140,39 +95,7 @@ public class AnnotationHelper {
 		return getElementUtils().getTypeElement(qualifiedName);
 	}
 
-	public boolean isParcelType(TypeMirror typeMirror) {
-		return isParcelType(typeMirror, true);
-	}
-
-	public boolean isParcelType(TypeMirror typeMirror, boolean root) {
-		if (typeMirror instanceof DeclaredType && getElementUtils().getTypeElement(PARCEL_ANNOTATION) != null) {
-			DeclaredType declaredType = (DeclaredType) typeMirror;
-			TypeElement element = (TypeElement) declaredType.asElement();
-
-			String name = element.getQualifiedName().toString();
-
-			if (isAnnotatedWith(element, PARCEL_ANNOTATION)) {
-				return true;
-			}
-
-			if (SUPPORTED_PARCEL_TYPES.containsKey(name)) {
-				boolean genericsMatch = true;
-
-				Integer genericsSize = SUPPORTED_PARCEL_TYPES.get(name);
-				if (genericsSize == declaredType.getTypeArguments().size()
-						&& (!root || genericsSize > 0)) {
-					for (int i = 0; i < genericsSize; i++) {
-						genericsMatch &= isParcelType(declaredType.getTypeArguments().get(i), false);
-					}
-
-					return genericsMatch;
-				}
-			}
-		}
-		return false;
-	}
-
-	private boolean isAnnotatedWith(Element element, String qualifiedName) {
+	public boolean isAnnotatedWith(Element element, String qualifiedName) {
 		for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
 			if (annotationMirror.getAnnotationType().toString().equals(qualifiedName)) {
 				return true;

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/AnnotationHelper.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/AnnotationHelper.java
@@ -22,8 +22,19 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
@@ -55,6 +66,40 @@ public class AnnotationHelper {
 
 	public static final String DEFAULT_FIELD_NAME_VALUE = "value";
 	public static final String DEFAULT_FIELD_NAME_RESNAME = "resName";
+	private static final String PARCEL_ANNOTATION = "org.parceler.Parcel";
+	private static final Map<String, Integer> SUPPORTED_PARCEL_TYPES = new HashMap<>();
+
+	static {
+		SUPPORTED_PARCEL_TYPES.put(Collection.class.getName(), 1);
+		SUPPORTED_PARCEL_TYPES.put(List.class.getName(), 1);
+		SUPPORTED_PARCEL_TYPES.put(ArrayList.class.getName(), 1);
+		SUPPORTED_PARCEL_TYPES.put(Set.class.getName(), 1);
+		SUPPORTED_PARCEL_TYPES.put(HashSet.class.getName(), 2);
+		SUPPORTED_PARCEL_TYPES.put(TreeSet.class.getName(), 2);
+		SUPPORTED_PARCEL_TYPES.put(CanonicalNameConstants.SPARSE_ARRAY, 1);
+		SUPPORTED_PARCEL_TYPES.put(Map.class.getName(), 2);
+		SUPPORTED_PARCEL_TYPES.put(HashMap.class.getName(), 2);
+		SUPPORTED_PARCEL_TYPES.put(TreeMap.class.getName(), 2);
+		SUPPORTED_PARCEL_TYPES.put(Integer.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(Long.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(Double.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(Float.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(Byte.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(String.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(Character.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(Boolean.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(byte[].class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(char[].class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(boolean[].class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(CanonicalNameConstants.IBINDER, 0);
+		SUPPORTED_PARCEL_TYPES.put(CanonicalNameConstants.BUNDLE, 0);
+		SUPPORTED_PARCEL_TYPES.put(CanonicalNameConstants.SPARSE_BOOLEAN_ARRAY, 0);
+		SUPPORTED_PARCEL_TYPES.put(LinkedList.class.getName(), 1);
+		SUPPORTED_PARCEL_TYPES.put(LinkedHashMap.class.getName(), 2);
+		SUPPORTED_PARCEL_TYPES.put(SortedMap.class.getName(), 2);
+		SUPPORTED_PARCEL_TYPES.put(SortedSet.class.getName(), 1);
+		SUPPORTED_PARCEL_TYPES.put(LinkedHashSet.class.getName(), 1);
+	};
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(AnnotationHelper.class);
 
@@ -93,6 +138,47 @@ public class AnnotationHelper {
 	 */
 	public TypeElement typeElementFromQualifiedName(String qualifiedName) {
 		return getElementUtils().getTypeElement(qualifiedName);
+	}
+
+	public boolean isParcelType(TypeMirror typeMirror) {
+		return isParcelType(typeMirror, true);
+	}
+
+	public boolean isParcelType(TypeMirror typeMirror, boolean root) {
+		if (typeMirror instanceof DeclaredType && getElementUtils().getTypeElement(PARCEL_ANNOTATION) != null) {
+			DeclaredType declaredType = (DeclaredType) typeMirror;
+			TypeElement element = (TypeElement) declaredType.asElement();
+
+			String name = element.getQualifiedName().toString();
+
+			if (isAnnotatedWith(element, PARCEL_ANNOTATION)) {
+				return true;
+			}
+
+			if (SUPPORTED_PARCEL_TYPES.containsKey(name)) {
+				boolean genericsMatch = true;
+
+				Integer genericsSize = SUPPORTED_PARCEL_TYPES.get(name);
+				if (genericsSize == declaredType.getTypeArguments().size()
+						&& (!root || genericsSize > 0)) {
+					for (int i = 0; i < genericsSize; i++) {
+						genericsMatch &= isParcelType(declaredType.getTypeArguments().get(i), false);
+					}
+
+					return genericsMatch;
+				}
+			}
+		}
+		return false;
+	}
+
+	private boolean isAnnotatedWith(Element element, String qualifiedName) {
+		for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
+			if (annotationMirror.getAnnotationType().toString().equals(qualifiedName)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public String generatedClassQualifiedNameFromQualifiedName(String qualifiedName) {
@@ -443,5 +529,4 @@ public class AnnotationHelper {
 		}
 		return false;
 	}
-
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/BundleHelper.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/BundleHelper.java
@@ -78,6 +78,7 @@ public class BundleHelper {
 
 	private AndroidAnnotationsEnvironment environment;
 	private AnnotationHelper annotationHelper;
+	private ParcelerHelper parcelerHelper;
 	private APTCodeModelHelper codeModelHelper;
 
 	private TypeMirror element;
@@ -95,6 +96,7 @@ public class BundleHelper {
 		this.environment = environment;
 		annotationHelper = new AnnotationHelper(environment);
 		codeModelHelper = new APTCodeModelHelper(environment);
+		parcelerHelper = new ParcelerHelper(environment);
 		this.element = element;
 
 		String typeString = element.toString();
@@ -174,7 +176,7 @@ public class BundleHelper {
 			if (isTypeParcelable(type)) {
 				methodNameToSave = "put" + "Parcelable";
 				methodNameToRestore = "get" + "Parcelable";
-			} else if (annotationHelper.isParcelType(type)) {
+			} else if (parcelerHelper.isParcelType(type)) {
 				methodNameToSave = "put" + "Parcelable";
 				methodNameToRestore = "get" + "Parcelable";
 				parcelerBean = true;
@@ -232,7 +234,7 @@ public class BundleHelper {
 		}
 
 		if (parcelerBean) {
-			expressionToRestore = environment.getCodeModel().ref("org.parceler.Parcels").staticInvoke("unwrap").arg(expressionToRestore);
+			expressionToRestore = environment.getCodeModel().ref(CanonicalNameConstants.PARCELS_UTILITY_CLASS).staticInvoke("unwrap").arg(expressionToRestore);
 		}
 
 		if (restoreCallNeedCastStatement) {
@@ -248,7 +250,7 @@ public class BundleHelper {
 	public IJStatement getExpressionToSaveFromField(IJExpression saveStateBundleParam, IJExpression fieldName, IJExpression variableRef) {
 		IJExpression refExpression = variableRef;
 		if (parcelerBean) {
-			refExpression = environment.getCodeModel().ref("org.parceler.Parcels").staticInvoke("wrap").arg(refExpression);
+			refExpression = environment.getCodeModel().ref(CanonicalNameConstants.PARCELS_UTILITY_CLASS).staticInvoke("wrap").arg(refExpression);
 		}
 		return JExpr.invoke(saveStateBundleParam, methodNameToSave).arg(fieldName).arg(refExpression);
 	}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
@@ -58,6 +58,9 @@ public final class CanonicalNameConstants {
 	public static final String INTENT_FILTER = "android.content.IntentFilter";
 	public static final String COMPONENT_NAME = "android.content.ComponentName";
 	public static final String BUNDLE = "android.os.Bundle";
+	public static final String IBINDER = "android.os.IBinder";
+	public static final String SPARSE_ARRAY = "android.util.SparseArray";
+	public static final String SPARSE_BOOLEAN_ARRAY = "android.util.SparseBooleanArray";
 	public static final String APPLICATION = "android.app.Application";
 	public static final String ACTIVITY = "android.app.Activity";
 	public static final String EDITABLE = "android.text.Editable";

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
@@ -151,6 +151,12 @@ public final class CanonicalNameConstants {
 	public static final String SCHEME_REGISTRY = "org.apache.http.conn.scheme.SchemeRegistry";
 	public static final String SINGLE_CLIENT_CONN_MANAGER = "org.apache.http.impl.conn.SingleClientConnManager";
 
+	/*
+	 * Parceler
+	 */
+	public static final String PARCEL_ANNOTATION = "org.parceler.Parcel";
+	public static final String PARCELS_UTILITY_CLASS = "org.parceler.Parcels";
+
 	private CanonicalNameConstants() {
 	}
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/ParcelerHelper.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/ParcelerHelper.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.helper;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+
+import org.androidannotations.AndroidAnnotationsEnvironment;
+
+public class ParcelerHelper extends AnnotationHelper {
+
+	private static final Map<String, Integer> SUPPORTED_PARCEL_TYPES = new HashMap<>();
+
+	static {
+		SUPPORTED_PARCEL_TYPES.put(Collection.class.getName(), 1);
+		SUPPORTED_PARCEL_TYPES.put(List.class.getName(), 1);
+		SUPPORTED_PARCEL_TYPES.put(ArrayList.class.getName(), 1);
+		SUPPORTED_PARCEL_TYPES.put(Set.class.getName(), 1);
+		SUPPORTED_PARCEL_TYPES.put(HashSet.class.getName(), 2);
+		SUPPORTED_PARCEL_TYPES.put(TreeSet.class.getName(), 2);
+		SUPPORTED_PARCEL_TYPES.put(CanonicalNameConstants.SPARSE_ARRAY, 1);
+		SUPPORTED_PARCEL_TYPES.put(Map.class.getName(), 2);
+		SUPPORTED_PARCEL_TYPES.put(HashMap.class.getName(), 2);
+		SUPPORTED_PARCEL_TYPES.put(TreeMap.class.getName(), 2);
+		SUPPORTED_PARCEL_TYPES.put(Integer.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(Long.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(Double.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(Float.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(Byte.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(String.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(Character.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(Boolean.class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(byte[].class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(char[].class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(boolean[].class.getName(), 0);
+		SUPPORTED_PARCEL_TYPES.put(CanonicalNameConstants.IBINDER, 0);
+		SUPPORTED_PARCEL_TYPES.put(CanonicalNameConstants.BUNDLE, 0);
+		SUPPORTED_PARCEL_TYPES.put(CanonicalNameConstants.SPARSE_BOOLEAN_ARRAY, 0);
+		SUPPORTED_PARCEL_TYPES.put(LinkedList.class.getName(), 1);
+		SUPPORTED_PARCEL_TYPES.put(LinkedHashMap.class.getName(), 2);
+		SUPPORTED_PARCEL_TYPES.put(SortedMap.class.getName(), 2);
+		SUPPORTED_PARCEL_TYPES.put(SortedSet.class.getName(), 1);
+		SUPPORTED_PARCEL_TYPES.put(LinkedHashSet.class.getName(), 1);
+	};
+
+	public ParcelerHelper(AndroidAnnotationsEnvironment environment) {
+		super(environment);
+	}
+
+	public boolean isParcelType(TypeMirror typeMirror) {
+		return isParcelType(typeMirror, true);
+	}
+
+	public boolean isParcelType(TypeMirror typeMirror, boolean root) {
+		if (typeMirror instanceof DeclaredType && getElementUtils().getTypeElement(CanonicalNameConstants.PARCEL_ANNOTATION) != null) {
+			DeclaredType declaredType = (DeclaredType) typeMirror;
+			TypeElement element = (TypeElement) declaredType.asElement();
+
+			String name = element.getQualifiedName().toString();
+
+			if (isAnnotatedWith(element, CanonicalNameConstants.PARCEL_ANNOTATION)) {
+				return true;
+			}
+
+			if (SUPPORTED_PARCEL_TYPES.containsKey(name)) {
+				boolean genericsMatch = true;
+
+				Integer genericsSize = SUPPORTED_PARCEL_TYPES.get(name);
+				if (genericsSize == declaredType.getTypeArguments().size()
+						&& (!root || genericsSize > 0)) {
+					for (int i = 0; i < genericsSize; i++) {
+						genericsMatch &= isParcelType(declaredType.getTypeArguments().get(i), false);
+					}
+
+					return genericsMatch;
+				}
+			}
+		}
+		return false;
+	}
+}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
@@ -73,12 +73,14 @@ public class ValidatorHelper {
 			CanonicalNameConstants.SUPPORT_V14_PREFERENCE_FRAGMENT);
 
 	protected final TargetAnnotationHelper annotationHelper;
+	private final ParcelerHelper parcelerHelper;
 
 	public final ValidatorParameterHelper param;
 
 	public ValidatorHelper(TargetAnnotationHelper targetAnnotationHelper) {
 		annotationHelper = targetAnnotationHelper;
 		param = new ValidatorParameterHelper(annotationHelper);
+		parcelerHelper = new ParcelerHelper(environment());
 	}
 
 	protected AndroidAnnotationsEnvironment environment() {
@@ -558,7 +560,7 @@ public class ValidatorHelper {
 				TypeMirror serializableType = annotationHelper.typeElementFromQualifiedName("java.io.Serializable").asType();
 				if (!annotationHelper.isSubtype(typeMirror, parcelableType)
 						&& !annotationHelper.isSubtype(typeMirror, serializableType)
-						&& !annotationHelper.isParcelType(typeMirror)) {
+						&& !parcelerHelper.isParcelType(typeMirror)) {
 					valid.addError("Unrecognized type. Please let your attribute be primitive or implement Serializable or Parcelable or an annotated Parceler bean.");
 				}
 			}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/ValidatorHelper.java
@@ -556,8 +556,10 @@ public class ValidatorHelper {
 			if (typeMirror.getKind() != TypeKind.NONE) {
 				TypeMirror parcelableType = annotationHelper.typeElementFromQualifiedName(CanonicalNameConstants.PARCELABLE).asType();
 				TypeMirror serializableType = annotationHelper.typeElementFromQualifiedName("java.io.Serializable").asType();
-				if (!annotationHelper.isSubtype(typeMirror, parcelableType) && !annotationHelper.isSubtype(typeMirror, serializableType)) {
-					valid.addError("Unrecognized type. Please let your attribute be primitive or implement Serializable or Parcelable");
+				if (!annotationHelper.isSubtype(typeMirror, parcelableType)
+						&& !annotationHelper.isSubtype(typeMirror, serializableType)
+						&& !annotationHelper.isParcelType(typeMirror)) {
+					valid.addError("Unrecognized type. Please let your attribute be primitive or implement Serializable or Parcelable or an annotated Parceler bean.");
 				}
 			}
 		}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/FragmentArgHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/FragmentArgHandler.java
@@ -107,7 +107,7 @@ public class FragmentArgHandler extends BaseAnnotationHandler<EFragmentHolder> {
 
 		JMethod method = builderClass.method(PUBLIC, holder.narrow(builderClass), fieldName);
 		JVar arg = method.param(paramClass, fieldName);
-		method.body().invoke(builderArgsField, bundleHelper.getMethodNameToSave()).arg(argKeyStaticField).arg(arg);
+		method.body().add(bundleHelper.getExpressionToSaveFromField(builderArgsField, argKeyStaticField, arg));
 		method.body()._return(_this());
 
 		String docComment = getProcessingEnvironment().getElementUtils().getDocComment(element);

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/InstanceStateHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/InstanceStateHandler.java
@@ -66,7 +66,7 @@ public class InstanceStateHandler extends BaseAnnotationHandler<HasInstanceState
 		BundleHelper bundleHelper = new BundleHelper(getEnvironment(), type);
 
 		JFieldRef ref = ref(fieldName);
-		saveStateBody.invoke(saveStateBundleParam, bundleHelper.getMethodNameToSave()).arg(fieldName).arg(ref);
+		saveStateBody.add(bundleHelper.getExpressionToSaveFromField(saveStateBundleParam, JExpr.lit(fieldName), ref));
 
 		IJExpression restoreMethodCall = bundleHelper.getExpressionToRestoreFromBundle(elementClass, restoreStateBundleParam, JExpr.lit(fieldName), restoreStateMethod);
 		restoreStateBody.assign(ref, restoreMethodCall);

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/helper/IntentBuilder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/helper/IntentBuilder.java
@@ -38,6 +38,7 @@ import javax.lang.model.util.Types;
 import org.androidannotations.AndroidAnnotationsEnvironment;
 import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.AndroidManifest;
+import org.androidannotations.helper.AnnotationHelper;
 import org.androidannotations.helper.Pair;
 import org.androidannotations.holder.HasIntentBuilder;
 import org.androidannotations.internal.process.ProcessHolder;
@@ -68,11 +69,13 @@ public abstract class IntentBuilder {
 	protected Elements elementUtils;
 	protected Types typeUtils;
 	protected APTCodeModelHelper codeModelHelper;
+	protected AnnotationHelper annotationHelper;
 
 	public IntentBuilder(HasIntentBuilder holder, AndroidManifest androidManifest) {
 		this.environment = holder.getEnvironment();
 		this.holder = holder;
 		this.androidManifest = androidManifest;
+		this.annotationHelper = new AnnotationHelper(environment);
 		codeModelHelper = new APTCodeModelHelper(environment);
 		elementUtils = environment.getProcessingEnvironment().getElementUtils();
 		typeUtils = environment.getProcessingEnvironment().getTypeUtils();

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/helper/IntentBuilder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/helper/IntentBuilder.java
@@ -40,7 +40,9 @@ import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.AndroidManifest;
 import org.androidannotations.helper.AnnotationHelper;
 import org.androidannotations.helper.BundleHelper;
+import org.androidannotations.helper.CanonicalNameConstants;
 import org.androidannotations.helper.Pair;
+import org.androidannotations.helper.ParcelerHelper;
 import org.androidannotations.holder.HasIntentBuilder;
 import org.androidannotations.internal.process.ProcessHolder;
 
@@ -71,12 +73,14 @@ public abstract class IntentBuilder {
 	protected Types typeUtils;
 	protected APTCodeModelHelper codeModelHelper;
 	protected AnnotationHelper annotationHelper;
+	protected ParcelerHelper parcelerHelper;
 
 	public IntentBuilder(HasIntentBuilder holder, AndroidManifest androidManifest) {
 		this.environment = holder.getEnvironment();
 		this.holder = holder;
 		this.androidManifest = androidManifest;
 		this.annotationHelper = new AnnotationHelper(environment);
+		this.parcelerHelper = new ParcelerHelper(environment);
 		codeModelHelper = new APTCodeModelHelper(environment);
 		elementUtils = environment.getProcessingEnvironment().getElementUtils();
 		typeUtils = environment.getProcessingEnvironment().getTypeUtils();
@@ -135,7 +139,7 @@ public abstract class IntentBuilder {
 
 	public JInvocation getSuperPutExtraInvocation(TypeMirror elementType, JVar extraParam, JFieldVar extraKeyField) {
 		IJExpression extraParameterArg = extraParam;
-		// Cast to Parcelable or Serializable if needed
+		// Cast to Parcelable, wrap with Parcels.wrap or cast Serializable if needed
 		if (elementType.getKind() == TypeKind.DECLARED) {
 			Elements elementUtils = environment.getProcessingEnvironment().getElementUtils();
 			TypeMirror parcelableType = elementUtils.getTypeElement(PARCELABLE).asType();
@@ -144,8 +148,8 @@ public abstract class IntentBuilder {
 				if (typeUtils.isSubtype(elementType, serializableType)) {
 					extraParameterArg = cast(environment.getClasses().PARCELABLE, extraParameterArg);
 				}
-			} else if (!BundleHelper.METHOD_SUFFIX_BY_TYPE_NAME.containsKey(elementType.toString()) && annotationHelper.isParcelType(elementType)) {
-				extraParameterArg = environment.getCodeModel().ref("org.parceler.Parcels").staticInvoke("wrap").arg(extraParameterArg);
+			} else if (!BundleHelper.METHOD_SUFFIX_BY_TYPE_NAME.containsKey(elementType.toString()) && parcelerHelper.isParcelType(elementType)) {
+				extraParameterArg = environment.getCodeModel().ref(CanonicalNameConstants.PARCELS_UTILITY_CLASS).staticInvoke("wrap").arg(extraParameterArg);
 			} else {
 				TypeMirror stringType = elementUtils.getTypeElement(STRING).asType();
 				if (!typeUtils.isSubtype(elementType, stringType)) {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/helper/IntentBuilder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/helper/IntentBuilder.java
@@ -39,6 +39,7 @@ import org.androidannotations.AndroidAnnotationsEnvironment;
 import org.androidannotations.helper.APTCodeModelHelper;
 import org.androidannotations.helper.AndroidManifest;
 import org.androidannotations.helper.AnnotationHelper;
+import org.androidannotations.helper.BundleHelper;
 import org.androidannotations.helper.Pair;
 import org.androidannotations.holder.HasIntentBuilder;
 import org.androidannotations.internal.process.ProcessHolder;
@@ -138,15 +139,17 @@ public abstract class IntentBuilder {
 		if (elementType.getKind() == TypeKind.DECLARED) {
 			Elements elementUtils = environment.getProcessingEnvironment().getElementUtils();
 			TypeMirror parcelableType = elementUtils.getTypeElement(PARCELABLE).asType();
-			if (!typeUtils.isSubtype(elementType, parcelableType)) {
-				TypeMirror stringType = elementUtils.getTypeElement(STRING).asType();
-				if (!typeUtils.isSubtype(elementType, stringType)) {
-					extraParameterArg = cast(environment.getClasses().SERIALIZABLE, extraParameterArg);
-				}
-			} else {
+			if (typeUtils.isSubtype(elementType, parcelableType)) {
 				TypeMirror serializableType = elementUtils.getTypeElement(SERIALIZABLE).asType();
 				if (typeUtils.isSubtype(elementType, serializableType)) {
 					extraParameterArg = cast(environment.getClasses().PARCELABLE, extraParameterArg);
+				}
+			} else if (!BundleHelper.METHOD_SUFFIX_BY_TYPE_NAME.containsKey(elementType.toString()) && annotationHelper.isParcelType(elementType)) {
+				extraParameterArg = environment.getCodeModel().ref("org.parceler.Parcels").staticInvoke("wrap").arg(extraParameterArg);
+			} else {
+				TypeMirror stringType = elementUtils.getTypeElement(STRING).asType();
+				if (!typeUtils.isSubtype(elementType, stringType)) {
+					extraParameterArg = cast(environment.getClasses().SERIALIZABLE, extraParameterArg);
 				}
 			}
 		}


### PR DESCRIPTION
This PR offers [Parceler](http://parceler.org) integration which wraps and unwraps beans annotated with `@Parcel` transparently when they are used in `@Extra` or `@InstanceState` aspects.  This is a rework of this previous PR: #977 