### PR TITLE
Create blocks for injection and after injection

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EActivityHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EActivityHolder.java
@@ -443,7 +443,7 @@ public class EActivityHolder extends EComponentWithViewSupportHolder implements 
 		injectExtrasBlock = injectExtrasBody._if(injectExtras.ne(_null()))._then();
 
 		getSetIntent().body().invoke(injectExtrasMethod);
-		getInitBody().invoke(injectExtrasMethod);
+		getInitBodyInjectionBlock().invoke(injectExtrasMethod);
 	}
 
 	public JMethod getOnNewIntent() {
@@ -554,7 +554,7 @@ public class EActivityHolder extends EComponentWithViewSupportHolder implements 
 	}
 
 	private void setInitNonConfigurationInstance() throws JClassAlreadyExistsException {
-		JBlock initBody = getInitBody();
+		JBlock initBody = getInitBodyInjectionBlock();
 		JDefinedClass ncHolderClass = getNonConfigurationHolder().getGeneratedClass();
 		initNonConfigurationInstance = initBody.decl(ncHolderClass, "nonConfigurationInstance", cast(ncHolderClass, _super().invoke(getGetLastNonConfigurationInstance())));
 		initIfNonConfigurationNotNullBlock = initBody._if(initNonConfigurationInstance.ne(_null()))._then();
@@ -730,7 +730,7 @@ public class EActivityHolder extends EComponentWithViewSupportHolder implements 
 
 	@Override
 	public JBlock getIntentFilterInitializationBlock(IntentFilterData intentFilterData) {
-		return getInitBody();
+		return getInitBodyInjectionBlock();
 	}
 
 	@Override
@@ -739,8 +739,13 @@ public class EActivityHolder extends EComponentWithViewSupportHolder implements 
 	}
 
 	@Override
-	public JBlock getAddPreferencesFromResourceBlock() {
-		return preferencesHolder.getAddPreferencesFromResourceBlock();
+	public JBlock getAddPreferencesFromResourceInjectionBlock() {
+		return preferencesHolder.getAddPreferencesFromResourceInjectionBlock();
+	}
+
+	@Override
+	public JBlock getAddPreferencesFromResourceAfterInjectionBlock() {
+		return preferencesHolder.getAddPreferencesFromResourceAfterInjectionBlock();
 	}
 
 	@Override

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentHolder.java
@@ -34,6 +34,8 @@ public abstract class EComponentHolder extends BaseGeneratedClassHolder {
 
 	protected IJExpression contextRef;
 	protected JMethod init;
+	private JBlock initBodyInjectionBlock;
+	private JBlock initBodyAfterInjectionBlock;
 	private JVar resourcesRef;
 	private JFieldVar powerManagerRef;
 
@@ -63,6 +65,27 @@ public abstract class EComponentHolder extends BaseGeneratedClassHolder {
 		return getInit().body();
 	}
 
+	public JBlock getInitBodyInjectionBlock() {
+		if (initBodyInjectionBlock == null) {
+			setInitBodyBlocks();
+		}
+
+		return initBodyInjectionBlock;
+	}
+
+	public JBlock getInitBodyAfterInjectionBlock() {
+		if (initBodyAfterInjectionBlock == null) {
+			setInitBodyBlocks();
+		}
+
+		return initBodyAfterInjectionBlock;
+	}
+
+	private void setInitBodyBlocks() {
+		initBodyInjectionBlock = getInitBody().blockSimple();
+		initBodyAfterInjectionBlock = getInitBody().blockSimple();
+	}
+
 	public JVar getResourcesRef() {
 		if (resourcesRef == null) {
 			setResourcesRef();
@@ -71,7 +94,7 @@ public abstract class EComponentHolder extends BaseGeneratedClassHolder {
 	}
 
 	private void setResourcesRef() {
-		resourcesRef = getInitBody().decl(getClasses().RESOURCES, "resources" + generationSuffix(), getContextRef().invoke("getResources"));
+		resourcesRef = getInitBodyInjectionBlock().decl(getClasses().RESOURCES, "resources" + generationSuffix(), getContextRef().invoke("getResources"));
 	}
 
 	public JFieldVar getPowerManagerRef() {
@@ -83,7 +106,7 @@ public abstract class EComponentHolder extends BaseGeneratedClassHolder {
 	}
 
 	private void setPowerManagerRef() {
-		JBlock methodBody = getInitBody();
+		JBlock methodBody = getInitBodyInjectionBlock();
 
 		JFieldRef serviceRef = getClasses().CONTEXT.staticRef("POWER_SERVICE");
 		powerManagerRef = getGeneratedClass().field(PRIVATE, getClasses().POWER_MANAGER, "powerManager" + generationSuffix());

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentHolder.java
@@ -82,8 +82,8 @@ public abstract class EComponentHolder extends BaseGeneratedClassHolder {
 	}
 
 	private void setInitBodyBlocks() {
-		initBodyInjectionBlock = getInitBody().blockSimple();
-		initBodyAfterInjectionBlock = getInitBody().blockSimple();
+		initBodyInjectionBlock = getInitBody().blockVirtual();
+		initBodyAfterInjectionBlock = getInitBody().blockVirtual();
 	}
 
 	public JVar getResourcesRef() {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentWithViewSupportHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentWithViewSupportHolder.java
@@ -52,7 +52,9 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder i
 	protected ViewNotifierHelper viewNotifierHelper;
 	private JMethod onViewChanged;
 	private JBlock onViewChangedBody;
-	private JBlock onViewChangedBodyBeforeFindViews;
+	private JBlock onViewChangedBodyInjectionBlock;
+	private JBlock onViewChangedBodyAfterInjectionBlock;
+	private JBlock onViewChangedBodyBeforeInjectionBlock;
 	private JVar onViewChangedHasViewsParam;
 	protected Map<String, FoundHolder> foundHolders = new HashMap<>();
 	protected JMethod findNativeFragmentById;
@@ -76,11 +78,25 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder i
 		return onViewChangedBody;
 	}
 
-	public JBlock getOnViewChangedBodyBeforeFindViews() {
-		if (onViewChangedBodyBeforeFindViews == null) {
+	public JBlock getOnViewChangedBodyBeforeInjectionBlock() {
+		if (onViewChangedBodyBeforeInjectionBlock == null) {
 			setOnViewChanged();
 		}
-		return onViewChangedBodyBeforeFindViews;
+		return onViewChangedBodyBeforeInjectionBlock;
+	}
+
+	public JBlock getOnViewChangedBodyInjectionBlock() {
+		if (onViewChangedBodyInjectionBlock == null) {
+			setOnViewChanged();
+		}
+		return onViewChangedBodyInjectionBlock;
+	}
+
+	public JBlock getOnViewChangedBodyAfterInjectionBlock() {
+		if (onViewChangedBodyAfterInjectionBlock == null) {
+			setOnViewChanged();
+		}
+		return onViewChangedBodyAfterInjectionBlock;
 	}
 
 	public JVar getOnViewChangedHasViewsParam() {
@@ -95,10 +111,12 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder i
 		onViewChanged = getGeneratedClass().method(PUBLIC, getCodeModel().VOID, "onViewChanged");
 		onViewChanged.annotate(Override.class);
 		onViewChangedBody = onViewChanged.body();
-		onViewChangedBodyBeforeFindViews = onViewChangedBody.blockSimple();
+		onViewChangedBodyBeforeInjectionBlock = onViewChangedBody.blockSimple();
+		onViewChangedBodyInjectionBlock = onViewChangedBody.blockSimple();
+		onViewChangedBodyAfterInjectionBlock = onViewChangedBody.blockSimple();
 		onViewChangedHasViewsParam = onViewChanged.param(HasViews.class, "hasViews");
 		AbstractJClass notifierClass = getJClass(OnViewChangedNotifier.class);
-		getInitBody().staticInvoke(notifierClass, "registerOnViewChangedListener").arg(_this());
+		getInitBodyInjectionBlock().staticInvoke(notifierClass, "registerOnViewChangedListener").arg(_this());
 	}
 
 	public JInvocation findViewById(JFieldRef idRef) {
@@ -115,7 +133,7 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder i
 		String idRefString = idRef.name();
 		FoundViewHolder foundViewHolder = (FoundViewHolder) foundHolders.get(idRefString);
 
-		JBlock block = getOnViewChangedBody();
+		JBlock block = getOnViewChangedBodyInjectionBlock();
 		IJExpression assignExpression;
 
 		if (foundViewHolder != null) {
@@ -147,7 +165,7 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder i
 
 	protected FoundViewHolder createFoundViewAndIfNotNullBlock(JFieldRef idRef, AbstractJClass viewClass) {
 		IJExpression findViewExpression = findViewById(idRef);
-		JBlock block = getOnViewChangedBody().blockSimple();
+		JBlock block = getOnViewChangedBodyInjectionBlock().blockSimple();
 
 		if (viewClass == null) {
 			viewClass = getClasses().VIEW;
@@ -256,7 +274,7 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder i
 			viewClass = getJClass(viewParameterType.toString());
 		}
 
-		JBlock onViewChangedBody = getOnViewChangedBody().blockSimple();
+		JBlock onViewChangedBody = getOnViewChangedBodyInjectionBlock().blockSimple();
 		JVar viewVariable = onViewChangedBody.decl(FINAL, viewClass, "view", cast(viewClass, findViewById(idRef)));
 		onViewChangedBody._if(viewVariable.ne(JExpr._null()))._then() //
 		.invoke(viewVariable, "addTextChangedListener").arg(_new(onTextChangeListenerClass));

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentWithViewSupportHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentWithViewSupportHolder.java
@@ -111,9 +111,9 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder i
 		onViewChanged = getGeneratedClass().method(PUBLIC, getCodeModel().VOID, "onViewChanged");
 		onViewChanged.annotate(Override.class);
 		onViewChangedBody = onViewChanged.body();
-		onViewChangedBodyBeforeInjectionBlock = onViewChangedBody.blockSimple();
-		onViewChangedBodyInjectionBlock = onViewChangedBody.blockSimple();
-		onViewChangedBodyAfterInjectionBlock = onViewChangedBody.blockSimple();
+		onViewChangedBodyBeforeInjectionBlock = onViewChangedBody.blockVirtual();
+		onViewChangedBodyInjectionBlock = onViewChangedBody.blockVirtual();
+		onViewChangedBodyAfterInjectionBlock = onViewChangedBody.blockVirtual();
 		onViewChangedHasViewsParam = onViewChanged.param(HasViews.class, "hasViews");
 		AbstractJClass notifierClass = getJClass(OnViewChangedNotifier.class);
 		getInitBodyInjectionBlock().staticInvoke(notifierClass, "registerOnViewChangedListener").arg(_this());

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
@@ -370,7 +370,7 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 		injectBundleArgs = injectExtrasBody.decl(getClasses().BUNDLE, "args_", invoke("getArguments"));
 		injectArgsBlock = injectExtrasBody._if(injectBundleArgs.ne(_null()))._then();
 
-		getInitBody().invoke(injectArgsMethod);
+		getInitBodyInjectionBlock().invoke(injectArgsMethod);
 	}
 
 	@Override
@@ -535,7 +535,7 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 		if (RegisterAt.OnAttachOnDetach.equals(intentFilterData.getRegisterAt())) {
 			return getOnAttachAfterSuperBlock();
 		}
-		return getInitBody();
+		return getInitBodyInjectionBlock();
 	}
 
 	@Override
@@ -544,8 +544,13 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 	}
 
 	@Override
-	public JBlock getAddPreferencesFromResourceBlock() {
-		return preferencesDelegate.getAddPreferencesFromResourceBlock();
+	public JBlock getAddPreferencesFromResourceInjectionBlock() {
+		return preferencesDelegate.getAddPreferencesFromResourceInjectionBlock();
+	}
+
+	@Override
+	public JBlock getAddPreferencesFromResourceAfterInjectionBlock() {
+		return preferencesDelegate.getAddPreferencesFromResourceAfterInjectionBlock();
 	}
 
 	@Override

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EServiceHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EServiceHolder.java
@@ -97,7 +97,7 @@ public class EServiceHolder extends EComponentHolder implements HasIntentBuilder
 
 	@Override
 	public JBlock getIntentFilterInitializationBlock(IntentFilterData intentFilterData) {
-		return getInitBody();
+		return getInitBodyInjectionBlock();
 	}
 
 	@Override

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/HasPreferences.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/HasPreferences.java
@@ -23,7 +23,9 @@ public interface HasPreferences extends GeneratedClassHolder {
 
 	JBlock getPreferenceScreenInitializationBlock();
 
-	JBlock getAddPreferencesFromResourceBlock();
+	JBlock getAddPreferencesFromResourceInjectionBlock();
+
+	JBlock getAddPreferencesFromResourceAfterInjectionBlock();
 
 	void assignFindPreferenceByKey(JFieldRef idRef, AbstractJClass preferenceClass, JFieldRef fieldRef);
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/PreferencesDelegate.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/PreferencesDelegate.java
@@ -85,8 +85,8 @@ public class PreferencesDelegate extends GeneratedClassHolderDelegate<EComponent
 		method.annotate(Override.class);
 		JVar preferencesResIdParam = method.param(int.class, "preferencesResId");
 		method.body().invoke(JExpr._super(), "addPreferencesFromResource").arg(preferencesResIdParam);
-		addPreferencesFromResourceInjectionBlock = method.body().blockSimple();
-		addPreferencesFromResourceAfterInjectionBlock = method.body().blockSimple();
+		addPreferencesFromResourceInjectionBlock = method.body().blockVirtual();
+		addPreferencesFromResourceAfterInjectionBlock = method.body().blockVirtual();
 	}
 
 	private JInvocation findPreferenceByKey(JFieldRef idRef) {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/PreferencesDelegate.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/PreferencesDelegate.java
@@ -38,7 +38,8 @@ import com.helger.jcodemodel.JVar;
 
 public class PreferencesDelegate extends GeneratedClassHolderDelegate<EComponentWithViewSupportHolder> implements HasPreferences {
 
-	protected JBlock addPreferencesFromResourceBlock;
+	protected JBlock addPreferencesFromResourceInjectionBlock;
+	protected JBlock addPreferencesFromResourceAfterInjectionBlock;
 
 	private boolean usingSupportV7Preference = false;
 	private AbstractJClass basePreferenceClass;
@@ -64,11 +65,19 @@ public class PreferencesDelegate extends GeneratedClassHolderDelegate<EComponent
 	}
 
 	@Override
-	public JBlock getAddPreferencesFromResourceBlock() {
-		if (addPreferencesFromResourceBlock == null) {
+	public JBlock getAddPreferencesFromResourceInjectionBlock() {
+		if (addPreferencesFromResourceInjectionBlock == null) {
 			setAddPreferencesFromResourceBlock();
 		}
-		return addPreferencesFromResourceBlock;
+		return addPreferencesFromResourceInjectionBlock;
+	}
+
+	@Override
+	public JBlock getAddPreferencesFromResourceAfterInjectionBlock() {
+		if (addPreferencesFromResourceAfterInjectionBlock == null) {
+			setAddPreferencesFromResourceBlock();
+		}
+		return addPreferencesFromResourceAfterInjectionBlock;
 	}
 
 	private void setAddPreferencesFromResourceBlock() {
@@ -76,7 +85,8 @@ public class PreferencesDelegate extends GeneratedClassHolderDelegate<EComponent
 		method.annotate(Override.class);
 		JVar preferencesResIdParam = method.param(int.class, "preferencesResId");
 		method.body().invoke(JExpr._super(), "addPreferencesFromResource").arg(preferencesResIdParam);
-		addPreferencesFromResourceBlock = method.body();
+		addPreferencesFromResourceInjectionBlock = method.body().blockSimple();
+		addPreferencesFromResourceAfterInjectionBlock = method.body().blockSimple();
 	}
 
 	private JInvocation findPreferenceByKey(JFieldRef idRef) {
@@ -90,7 +100,7 @@ public class PreferencesDelegate extends GeneratedClassHolderDelegate<EComponent
 		String idRefString = idRef.name();
 		FoundPreferenceHolder foundViewHolder = (FoundPreferenceHolder) holder.foundHolders.get(idRefString);
 
-		JBlock block = getAddPreferencesFromResourceBlock();
+		JBlock block = getAddPreferencesFromResourceInjectionBlock();
 		IJExpression assignExpression;
 
 		if (foundViewHolder != null) {
@@ -129,7 +139,7 @@ public class PreferencesDelegate extends GeneratedClassHolderDelegate<EComponent
 
 	private FoundPreferenceHolder createFoundPreferenceAndIfNotNullBlock(JFieldRef idRef, AbstractJClass preferenceClass) {
 		IJExpression findPreferenceExpression = findPreferenceByKey(idRef);
-		JBlock block = getAddPreferencesFromResourceBlock().blockSimple();
+		JBlock block = getAddPreferencesFromResourceInjectionBlock().blockSimple();
 
 		if (preferenceClass == null) {
 			preferenceClass = basePreferenceClass;

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/CorePlugin.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/CorePlugin.java
@@ -195,19 +195,16 @@ public class CorePlugin extends AndroidAnnotationsPlugin {
 		annotationHandlers.add(new OnActivityResultHandler(androidAnnotationEnv));
 
 		annotationHandlers.add(new IgnoredWhenDetachedHandler(androidAnnotationEnv));
-		/* After injection methods must be after injections */
+
 		annotationHandlers.add(new AfterInjectHandler(androidAnnotationEnv));
 		annotationHandlers.add(new AfterExtrasHandler(androidAnnotationEnv));
 		annotationHandlers.add(new AfterViewsHandler(androidAnnotationEnv));
 
-		/* preference screen handler must be after injections */
 		annotationHandlers.add(new PreferenceScreenHandler(androidAnnotationEnv));
 		annotationHandlers.add(new PreferenceHeadersHandler(androidAnnotationEnv));
-		/* Preference injections must be after preference screen handler */
 		annotationHandlers.add(new PreferenceByKeyHandler(androidAnnotationEnv));
 		annotationHandlers.add(new PreferenceChangeHandler(androidAnnotationEnv));
 		annotationHandlers.add(new PreferenceClickHandler(androidAnnotationEnv));
-		/* After preference injection methods must be after preference injections */
 		annotationHandlers.add(new AfterPreferencesHandler(androidAnnotationEnv));
 
 		if (androidAnnotationEnv.getOptionBooleanValue(OPTION_TRACE)) {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/AbstractFragmentByHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/AbstractFragmentByHandler.java
@@ -66,7 +66,7 @@ public abstract class AbstractFragmentByHandler extends CoreBaseAnnotationHandle
 		boolean isNativeFragment = nativeFragmentElement != null && annotationHelper.isSubtype(elementType, nativeFragmentElement.asType());
 
 		String fieldName = element.getSimpleName().toString();
-		JBlock methodBody = holder.getOnViewChangedBody();
+		JBlock methodBody = holder.getOnViewChangedBodyInjectionBlock();
 
 		if (holder instanceof EFragmentHolder) {
 			boolean childFragment = annotationHelper.extractAnnotationParameter(element, "childFragment");

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/AbstractResHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/AbstractResHandler.java
@@ -59,7 +59,7 @@ public abstract class AbstractResHandler extends BaseAnnotationHandler<EComponen
 
 		JFieldRef idRef = annotationHelper.extractOneAnnotationFieldRef(element, resInnerClass, true);
 
-		JBlock methodBody = holder.getInitBody();
+		JBlock methodBody = holder.getInitBodyInjectionBlock();
 
 		makeCall(fieldName, holder, methodBody, idRef);
 	}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/AfterInjectHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/AfterInjectHandler.java
@@ -48,6 +48,6 @@ public class AfterInjectHandler extends BaseAnnotationHandler<EComponentHolder> 
 	@Override
 	public void process(Element element, EComponentHolder holder) {
 		String methodName = element.getSimpleName().toString();
-		holder.getInitBody().invoke(methodName);
+		holder.getInitBodyAfterInjectionBlock().invoke(methodName);
 	}
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/AfterPreferencesHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/AfterPreferencesHandler.java
@@ -49,6 +49,6 @@ public class AfterPreferencesHandler extends BaseAnnotationHandler<HasPreference
 	@Override
 	public void process(Element element, HasPreferences holder) {
 		String methodName = element.getSimpleName().toString();
-		holder.getAddPreferencesFromResourceBlock().invoke(methodName);
+		holder.getAddPreferencesFromResourceAfterInjectionBlock().invoke(methodName);
 	}
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/AfterViewsHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/AfterViewsHandler.java
@@ -48,6 +48,6 @@ public class AfterViewsHandler extends BaseAnnotationHandler<EComponentWithViewS
 	@Override
 	public void process(Element element, EComponentWithViewSupportHolder holder) throws Exception {
 		String methodName = element.getSimpleName().toString();
-		holder.getOnViewChangedBody().invoke(methodName);
+		holder.getOnViewChangedBodyAfterInjectionBlock().invoke(methodName);
 	}
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/AppHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/AppHandler.java
@@ -51,6 +51,6 @@ public class AppHandler extends BaseAnnotationHandler<EComponentHolder> {
 		String applicationQualifiedName = element.asType().toString();
 		AbstractJClass applicationClass = getJClass(applicationQualifiedName + classSuffix());
 
-		holder.getInitBody().assign(ref(fieldName), applicationClass.staticInvoke(EApplicationHolder.GET_APPLICATION_INSTANCE));
+		holder.getInitBodyInjectionBlock().assign(ref(fieldName), applicationClass.staticInvoke(EApplicationHolder.GET_APPLICATION_INSTANCE));
 	}
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/BeanHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/BeanHandler.java
@@ -63,7 +63,7 @@ public class BeanHandler extends BaseAnnotationHandler<EComponentHolder> {
 
 		String fieldName = element.getSimpleName().toString();
 		JFieldRef beanField = ref(fieldName);
-		JBlock block = holder.getInitBody();
+		JBlock block = holder.getInitBodyInjectionBlock();
 
 		boolean hasNonConfigurationInstanceAnnotation = element.getAnnotation(NonConfigurationInstance.class) != null;
 		if (hasNonConfigurationInstanceAnnotation) {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/CustomTitleHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/CustomTitleHandler.java
@@ -43,12 +43,12 @@ public class CustomTitleHandler extends BaseAnnotationHandler<EActivityHolder> {
 
 	@Override
 	public void process(Element element, EActivityHolder holder) {
-		JBlock onViewChangedBody = holder.getOnViewChangedBody();
+		JBlock onViewChangedBody = holder.getOnViewChangedBodyBeforeInjectionBlock();
 
 		JFieldRef contentViewId = annotationHelper.extractAnnotationFieldRefs(element, getTarget(), getEnvironment().getRClass().get(IRClass.Res.LAYOUT), false).get(0);
 
 		JFieldRef customTitleFeature = getClasses().WINDOW.staticRef("FEATURE_CUSTOM_TITLE");
-		holder.getInitBody().invoke("requestWindowFeature").arg(customTitleFeature);
+		holder.getInitBodyInjectionBlock().invoke("requestWindowFeature").arg(customTitleFeature);
 		onViewChangedBody.add(holder.getContextRef().invoke("getWindow").invoke("setFeatureInt").arg(customTitleFeature).arg(contentViewId));
 	}
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/FromHtmlHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/FromHtmlHandler.java
@@ -54,7 +54,7 @@ public class FromHtmlHandler extends BaseAnnotationHandler<EComponentWithViewSup
 
 		JFieldRef idRef = annotationHelper.extractOneAnnotationFieldRef(element, IRClass.Res.STRING, true);
 
-		JBlock methodBody = holder.getOnViewChangedBody();
+		JBlock methodBody = holder.getOnViewChangedBodyAfterInjectionBlock();
 		methodBody //
 				._if(ref(fieldName).ne(_null())) //
 				._then() //

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/FullscreenHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/FullscreenHandler.java
@@ -43,6 +43,6 @@ public class FullscreenHandler extends BaseAnnotationHandler<EActivityHolder> {
 	public void process(Element element, EActivityHolder holder) {
 		JFieldRef fullScreen = getClasses().WINDOW_MANAGER_LAYOUT_PARAMS.staticRef("FLAG_FULLSCREEN");
 		JInvocation setFlagsInvocation = invoke(invoke("getWindow"), "setFlags").arg(fullScreen).arg(fullScreen);
-		holder.getInitBody().add(setFlagsInvocation);
+		holder.getInitBodyInjectionBlock().add(setFlagsInvocation);
 	}
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/HierarchyViewerSupportHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/HierarchyViewerSupportHandler.java
@@ -46,7 +46,7 @@ public class HierarchyViewerSupportHandler extends BaseAnnotationHandler<EActivi
 	public void process(Element element, EActivityHolder holder) throws Exception {
 		JInvocation viewServerInvocation = getClasses().VIEW_SERVER.staticInvoke("get").arg(_this());
 
-		holder.getOnViewChangedBody().invoke(viewServerInvocation, "addWindow").arg(_this());
+		holder.getOnViewChangedBodyInjectionBlock().invoke(viewServerInvocation, "addWindow").arg(_this());
 		holder.getOnDestroyAfterSuperBlock().invoke(viewServerInvocation, "removeWindow").arg(_this());
 		holder.getOnResumeAfterSuperBlock().invoke(viewServerInvocation, "setFocusedWindow").arg(_this());
 	}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/HttpsClientHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/HttpsClientHandler.java
@@ -75,7 +75,7 @@ public class HttpsClientHandler extends BaseAnnotationHandler<EComponentHolder> 
 		boolean useCustomKeyStore = keyStoreRawIdRef != null;
 
 		String fieldName = element.getSimpleName().toString();
-		JBlock methodBody = holder.getInitBody();
+		JBlock methodBody = holder.getInitBodyInjectionBlock();
 
 		ProcessHolder.Classes classes = getClasses();
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/PrefHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/PrefHandler.java
@@ -71,7 +71,7 @@ public class PrefHandler extends CoreBaseAnnotationHandler<EComponentHolder> {
 			}
 		}
 
-		JBlock methodBody = holder.getInitBody();
+		JBlock methodBody = holder.getInitBodyInjectionBlock();
 		JFieldRef field = JExpr.ref(fieldName);
 		methodBody.assign(field, JExpr._new(prefClass).arg(holder.getContextRef()));
 	}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/RootContextHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/RootContextHandler.java
@@ -57,7 +57,7 @@ public class RootContextHandler extends BaseAnnotationHandler<EBeanHolder> {
 		TypeMirror elementType = element.asType();
 		String typeQualifiedName = elementType.toString();
 
-		JBlock body = holder.getInitBody();
+		JBlock body = holder.getInitBodyInjectionBlock();
 		IJExpression contextRef = holder.getContextRef();
 
 		if (CanonicalNameConstants.CONTEXT.equals(typeQualifiedName)) {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/SystemServiceHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/SystemServiceHandler.java
@@ -62,7 +62,7 @@ public class SystemServiceHandler extends BaseAnnotationHandler<EComponentHolder
 
 		JFieldRef serviceRef = new AndroidSystemServices(getEnvironment()).getServiceConstantRef(serviceType);
 
-		JBlock methodBody = holder.getInitBody();
+		JBlock methodBody = holder.getInitBodyInjectionBlock();
 
 		if (CanonicalNameConstants.APP_WIDGET_MANAGER.equals(fieldTypeQualifiedName)) {
 			createSpecialInjection(holder, fieldName, fieldTypeQualifiedName, serviceRef, methodBody, 21, "LOLLIPOP", getClasses().APP_WIDGET_MANAGER, "getInstance", true);

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/ViewsByIdHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/ViewsByIdHandler.java
@@ -79,7 +79,7 @@ public class ViewsByIdHandler extends BaseAnnotationHandler<EComponentWithViewSu
 		DeclaredType arrayListType = getProcessingEnvironment().getTypeUtils().getDeclaredType(arrayListTypeElement, viewType);
 		AbstractJClass arrayListClass = codeModelHelper.typeMirrorToJClass(arrayListType);
 
-		holder.getInitBody().assign(elementRef, _new(arrayListClass));
+		holder.getInitBodyInjectionBlock().assign(elementRef, _new(arrayListClass));
 	}
 
 	private TypeMirror extractViewClass(Element element) {
@@ -94,7 +94,7 @@ public class ViewsByIdHandler extends BaseAnnotationHandler<EComponentWithViewSu
 	}
 
 	private void clearList(JFieldRef elementRef, EComponentWithViewSupportHolder holder) {
-		holder.getOnViewChangedBodyBeforeFindViews().add(elementRef.invoke("clear"));
+		holder.getOnViewChangedBodyBeforeInjectionBlock().add(elementRef.invoke("clear"));
 	}
 
 	private void addViewToListIfNotNull(JFieldRef elementRef, AbstractJClass viewClass, JFieldRef idRef, EComponentWithViewSupportHolder holder) {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/WindowFeatureHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/WindowFeatureHandler.java
@@ -54,7 +54,7 @@ public class WindowFeatureHandler extends BaseAnnotationHandler<EActivityHolder>
 			methodName = "requestWindowFeature";
 		}
 		for (int feature : features) {
-			holder.getInitBody().invoke(methodName).arg(JExpr.lit(feature));
+			holder.getInitBodyInjectionBlock().invoke(methodName).arg(JExpr.lit(feature));
 		}
 	}
 }

--- a/AndroidAnnotations/androidannotations-ormlite/ormlite/src/main/java/org/androidannotations/ormlite/handler/OrmLiteDaoHandler.java
+++ b/AndroidAnnotations/androidannotations-ormlite/ormlite/src/main/java/org/androidannotations/ormlite/handler/OrmLiteDaoHandler.java
@@ -79,7 +79,7 @@ public class OrmLiteDaoHandler extends BaseAnnotationHandler<EComponentHolder> {
 		TypeMirror databaseHelperTypeMirror = annotationHelper.extractAnnotationParameter(element, "helper");
 		JFieldVar databaseHelperRef = ormLiteHolder.getDatabaseHelperRef(databaseHelperTypeMirror);
 
-		JBlock initBody = holder.getInitBody();
+		JBlock initBody = holder.getInitBodyInjectionBlock();
 
 		IJExpression injectExpr = databaseHelperRef.invoke("getDao").arg(modelClassDotClass);
 		if (elementExtendsRuntimeExceptionDao(element)) {

--- a/AndroidAnnotations/androidannotations-ormlite/ormlite/src/main/java/org/androidannotations/ormlite/holder/OrmLiteHolder.java
+++ b/AndroidAnnotations/androidannotations-ormlite/ormlite/src/main/java/org/androidannotations/ormlite/holder/OrmLiteHolder.java
@@ -59,7 +59,7 @@ public class OrmLiteHolder extends PluginClassHolder<EComponentHolder> {
 		databaseHelperRefs.put(databaseHelperTypeMirror, databaseHelperRef);
 
 		IJExpression dbHelperClass = databaseHelperClass.dotclass();
-		holder().getInitBody().assign(databaseHelperRef, //
+		holder().getInitBodyInjectionBlock().assign(databaseHelperRef, //
 				getJClass(OrmLiteClasses.OPEN_HELPER_MANAGER).staticInvoke("getHelper").arg(holder().getContextRef()).arg(dbHelperClass));
 
 		return databaseHelperRef;

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/handler/RestServiceHandler.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/handler/RestServiceHandler.java
@@ -59,7 +59,7 @@ public class RestServiceHandler extends BaseAnnotationHandler<EComponentHolder> 
 
 		AbstractJClass clazz = codeModelHelper.narrowGeneratedClass(getJClass(generatedClassName), fieldTypeMirror);
 
-		JBlock methodBody = holder.getInitBody();
+		JBlock methodBody = holder.getInitBodyInjectionBlock();
 
 		JFieldRef field = JExpr.ref(fieldName);
 

--- a/AndroidAnnotations/pom.xml
+++ b/AndroidAnnotations/pom.xml
@@ -167,7 +167,7 @@
 			<dependency>
 				<groupId>com.helger</groupId>
 				<artifactId>jcodemodel</artifactId>
-				<version>2.7.11</version>
+				<version>2.8.0</version>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>


### PR DESCRIPTION
Related to #1466.

This is incomplete. For some reasons, it generates the following:
```java
private void init_(Bundle savedInstanceState) {
	{
		Resources resources_ = this.getResources();
		injected_string = resources_.getString(R.string.injected_string);
		injectedString = resources_.getString(R.string.injected_string);
		helloHtml = Html.fromHtml(resources_.getString(R.string.hello_html));
		htmlInjected = Html.fromHtml(resources_.getString(R.string.hello_html));
	}
}
```

Note the extra block with braces and indent. I could not figure out why is this happening. Any help is much appreciated.