### PR TITLE
Fix @Patch validation

### DIFF
--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/helper/RestSpringValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/helper/RestSpringValidatorHelper.java
@@ -55,6 +55,7 @@ import org.androidannotations.rest.spring.annotations.Get;
 import org.androidannotations.rest.spring.annotations.Head;
 import org.androidannotations.rest.spring.annotations.Options;
 import org.androidannotations.rest.spring.annotations.Part;
+import org.androidannotations.rest.spring.annotations.Patch;
 import org.androidannotations.rest.spring.annotations.Path;
 import org.androidannotations.rest.spring.annotations.Post;
 import org.androidannotations.rest.spring.annotations.Put;
@@ -68,7 +69,7 @@ public class RestSpringValidatorHelper extends ValidatorHelper {
 
 	private static final List<String> VALID_REST_INTERFACES = asList(RestClientHeaders.class.getName(), RestClientErrorHandling.class.getName(),
 			RestClientRootUrl.class.getName(), RestClientSupport.class.getName());
-	private static final List<Class<? extends Annotation>> REST_ANNOTATION_CLASSES = Arrays.asList(Get.class, Head.class, Options.class, Post.class, Put.class, Delete.class);
+	private static final List<Class<? extends Annotation>> REST_ANNOTATION_CLASSES = Arrays.asList(Get.class, Head.class, Options.class, Post.class, Put.class, Patch.class, Delete.class);
 
 	private static final String METHOD_NAME_SET_ROOT_URL = "setRootUrl";
 	private static final String METHOD_NAME_SET_AUTHENTICATION = "setAuthentication";

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/helper/RestSpringValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/helper/RestSpringValidatorHelper.java
@@ -570,7 +570,7 @@ public class RestSpringValidatorHelper extends ValidatorHelper {
 	}
 
 	public void usesSpringAndroid2(Element element, ElementValidation validation) {
-		if (environment().getProcessingEnvironment().getElementUtils().getTypeElement(RestSpringClasses.PARAMETERIZED_TYPE_REFERENCE) != null) {
+		if (environment().getProcessingEnvironment().getElementUtils().getTypeElement(RestSpringClasses.PARAMETERIZED_TYPE_REFERENCE) == null) {
 			validation.addError(element, "To use %s annotated method you must add Spring Android Rest Template 2.0 to your classpath");
 		}
 	}

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/ClientWithPatch.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/ClientWithPatch.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.rest.spring;
+
+
+import org.androidannotations.rest.spring.annotations.Patch;
+import org.androidannotations.rest.spring.annotations.Rest;
+import org.springframework.http.converter.StringHttpMessageConverter;
+
+@Rest(converters = StringHttpMessageConverter.class)
+public interface ClientWithPatch {
+
+	@Patch("/")
+	void patchMethod(String entity);
+}

--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/RestTest.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/test/java/org/androidannotations/rest/spring/RestTest.java
@@ -155,4 +155,12 @@ public class RestTest extends AAProcessorTestHelper {
 		CompileResult result = compileFiles(ClientWithAllInterfaces.class);
 		assertCompilationSuccessful(result);
 	}
+
+	@Test
+	public void patchWithoutSpring2DoesNotCompile() throws IOException {
+		CompileResult result = compileFiles(ClientWithPatch.class);
+
+		assertCompilationErrorOn(ClientWithPatch.class, "@Patch(\"/\")", result);
+		assertCompilationErrorCount(1, result);
+	}
 }


### PR DESCRIPTION
Follow-up for #1587.

We should have tests for Spring 2. The most coverage would be if we create a new test project which uses Spring 2. Or we can just change the the version for 2, but that means we do not test important things which are differently generated in Spring 1.