### PR TITLE
1612 warn when propagation reuse is used with delay

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/UiThread.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/UiThread.java
@@ -137,6 +137,8 @@ public @interface UiThread {
 	 * if it is inside the UI thread already. If so, it will directly call the
 	 * method instead of using the handler. The default value is
 	 * {@link Propagation#ENQUEUE}, which will always call the handler.
+	 *
+	 * When using a non-zero {@link #delay() delay} the propagation parameter is ignored.
 	 * 
 	 * @return {@link Propagation#ENQUEUE} to always call the handler,
 	 *         {@link Propagation#REUSE}, to check whether it is already on the

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/UiThreadHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/UiThreadHandler.java
@@ -52,6 +52,13 @@ public class UiThreadHandler extends AbstractRunnableHandler {
 		super.validate(element, valid);
 
 		coreValidatorHelper.usesEnqueueIfHasId(element, valid);
+
+		UiThread annotation = element.getAnnotation(UiThread.class);
+		long delay = annotation.delay();
+		UiThread.Propagation propagation = annotation.propagation();
+		if (delay != 0 && propagation == UiThread.Propagation.REUSE) {
+			valid.addWarning("propagation=REUSE is ignored when using a delay");
+		}
 	}
 
 	@Override


### PR DESCRIPTION
add javadoc note to `UiThread#propagation()` that it is ignored for non-zero delay values and add a warning to the validation.

see https://github.com/excilys/androidannotations/issues/1612