### PR TITLE
Do not use ContextCompat if target method is not available

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/ContextCompatAwareResHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/ContextCompatAwareResHandler.java
@@ -47,9 +47,9 @@ abstract class ContextCompatAwareResHandler extends AbstractResHandler {
 	protected IJExpression getInstanceInvocation(EComponentHolder holder, JFieldRef idRef, IJAssignmentTarget fieldRef, JBlock targetBlock) {
 		if (hasTargetMethodInContextCompat()) {
 			return getClasses().CONTEXT_COMPAT.staticInvoke(androidRes.getResourceMethodName()).arg(holder.getContextRef()).arg(idRef);
-		} else if (shouldUseContextMethod() && !hasTargetMethodInContextCompat()) {
+		} else if (shouldUseContextMethod()) {
 			return holder.getContextRef().invoke(androidRes.getResourceMethodName()).arg(idRef);
-		} else if (!shouldUseContextMethod() && hasTargetMethodInContext() && !hasTargetMethodInContextCompat()) {
+		} else if (!shouldUseContextMethod() && hasTargetMethodInContext()) {
 			return createCallWithIfGuard(holder, idRef, fieldRef, targetBlock);
 		} else {
 			return invoke(holder.getResourcesRef(), androidRes.getResourceMethodName()).arg(idRef);

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/ContextCompatAwareResHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/ContextCompatAwareResHandler.java
@@ -45,11 +45,11 @@ abstract class ContextCompatAwareResHandler extends AbstractResHandler {
 
 	@Override
 	protected IJExpression getInstanceInvocation(EComponentHolder holder, JFieldRef idRef, IJAssignmentTarget fieldRef, JBlock targetBlock) {
-		if (hasContextCompatInClasspath()) {
+		if (hasTargetMethodInContextCompat()) {
 			return getClasses().CONTEXT_COMPAT.staticInvoke(androidRes.getResourceMethodName()).arg(holder.getContextRef()).arg(idRef);
-		} else if (shouldUseContextMethod() && !hasContextCompatInClasspath()) {
+		} else if (shouldUseContextMethod() && !hasTargetMethodInContextCompat()) {
 			return holder.getContextRef().invoke(androidRes.getResourceMethodName()).arg(idRef);
-		} else if (!shouldUseContextMethod() && hasTargetMethodInContext() && !hasContextCompatInClasspath()) {
+		} else if (!shouldUseContextMethod() && hasTargetMethodInContext() && !hasTargetMethodInContextCompat()) {
 			return createCallWithIfGuard(holder, idRef, fieldRef, targetBlock);
 		} else {
 			return invoke(holder.getResourcesRef(), androidRes.getResourceMethodName()).arg(idRef);
@@ -66,6 +66,12 @@ abstract class ContextCompatAwareResHandler extends AbstractResHandler {
 		return hasTargetMethod(context, androidRes.getResourceMethodName());
 	}
 
+	private boolean hasTargetMethodInContextCompat() {
+		TypeElement contextCompat = getProcessingEnvironment().getElementUtils().getTypeElement(CanonicalNameConstants.CONTEXT_COMPAT);
+
+		return hasTargetMethod(contextCompat, androidRes.getResourceMethodName());
+	}
+
 	private IJExpression createCallWithIfGuard(EComponentHolder holder, JFieldRef idRef, IJAssignmentTarget fieldRef, JBlock targetBlock) {
 		JVar resourcesRef = holder.getResourcesRef();
 		IJExpression buildVersionCondition = getClasses().BUILD_VERSION.staticRef("SDK_INT").gte(getClasses().BUILD_VERSION_CODES.staticRef(minSdkPlatformName));
@@ -75,9 +81,5 @@ abstract class ContextCompatAwareResHandler extends AbstractResHandler {
 		conditional._else().add(fieldRef.assign(resourcesRef.invoke(androidRes.getResourceMethodName()).arg(idRef)));
 
 		return null;
-	}
-
-	protected boolean hasContextCompatInClasspath() {
-		return getProcessingEnvironment().getElementUtils().getTypeElement(CanonicalNameConstants.CONTEXT_COMPAT) != null;
 	}
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/generation/ContextCompatColorTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/generation/ContextCompatColorTest.java
@@ -86,4 +86,16 @@ public class ContextCompatColorTest extends AAProcessorTestHelper {
 		assertGeneratedClassContains(generatedFile, COLOR_CONDITIONAL_WITHOUT_CONTEXT_COMPAT);
 	}
 
+	@Test
+	public void activityCompilesWithOldContextCompat() throws Exception {
+		addManifestProcessorParameter(ContextCompatColorTest.class, "AndroidManifestForColorMinSdk23.xml");
+
+		CompileResult result = compileFiles(ActivityWithGetColorMethod.class,
+				toPath(FragmentByChildFragmentManagerTest.class, "support/old/ContextCompat.java"));
+		File generatedFile = toGeneratedFile(ActivityWithGetColorMethod.class);
+
+		assertCompilationSuccessful(result);
+		assertGeneratedClassMatches(generatedFile, COLOR_VIA_CONTEXT_ON_MARSHMALLOW);
+	}
+
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/resources/org/androidannotations/generation/support/old/ContextCompat.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/resources/org/androidannotations/generation/support/old/ContextCompat.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package android.support.v4.content;
+
+public class ContextCompat {
+
+}


### PR DESCRIPTION
Fixes #1665.