### PR TITLE
Support Instant Run application class

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
@@ -141,6 +141,7 @@ public final class CanonicalNameConstants {
 	public static final String APPCOMPAT_ACTIVITY = "android.support.v7.app.AppCompatActivity";
 	public static final String VIEW_PAGER = "android.support.v4.view.ViewPager";
 	public static final String PAGE_CHANGE_LISTENER = "android.support.v4.view.ViewPager.OnPageChangeListener";
+	public static final String INSTANT_RUN_APPLICATION = "com.android.tools.fd.runtime.BootstrapApplication";
 
 	/*
 	 * Android permission

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/AndroidManifestFinder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/AndroidManifestFinder.java
@@ -36,6 +36,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.androidannotations.AndroidAnnotationsEnvironment;
 import org.androidannotations.Option;
 import org.androidannotations.helper.AndroidManifest;
+import org.androidannotations.helper.CanonicalNameConstants;
 import org.androidannotations.internal.exception.AndroidManifestNotFoundException;
 import org.androidannotations.logger.Logger;
 import org.androidannotations.logger.LoggerFactory;
@@ -259,7 +260,12 @@ public class AndroidManifestFinder {
 			Node applicationNode = applicationNodes.item(0);
 			Node nameAttribute = applicationNode.getAttributes().getNamedItem("android:name");
 
-			applicationClassQualifiedName = manifestNameToValidQualifiedName(applicationPackage, nameAttribute);
+			if (!hasInstantRunApplication(nameAttribute)) {
+				applicationClassQualifiedName = manifestNameToValidQualifiedName(applicationPackage, nameAttribute);
+			} else {
+				Node plainNameAttribute = applicationNode.getAttributes().getNamedItem("name");
+				applicationClassQualifiedName = manifestNameToValidQualifiedName(applicationPackage, plainNameAttribute);
+			}
 
 			if (applicationClassQualifiedName == null) {
 				if (nameAttribute != null) {
@@ -390,6 +396,10 @@ public class AndroidManifestFinder {
 			usesPermissionQualifiedNames.add(nameAttribute.getNodeValue());
 		}
 		return usesPermissionQualifiedNames;
+	}
+
+	private boolean hasInstantRunApplication(Node nameAttribute) {
+		return nameAttribute != null && CanonicalNameConstants.INSTANT_RUN_APPLICATION.equals(nameAttribute.getNodeValue());
 	}
 
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/manifest/InstantRunManifestTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/manifest/InstantRunManifestTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.manifest;
+
+import java.io.IOException;
+
+import org.androidannotations.internal.AndroidAnnotationProcessor;
+import org.androidannotations.testutils.AAProcessorTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class InstantRunManifestTest extends AAProcessorTestHelper {
+
+	@Before
+	public void setUp() {
+		addProcessor(AndroidAnnotationProcessor.class);
+	}
+
+	@Test
+	public void generatedAppInManifestCompiles() {
+		addManifestProcessorParameter(InstantRunManifestTest.class, "CorrectInstantRunManifest.xml");
+
+		CompileResult compileResult = compileFiles(MyApplication.class);
+
+		assertCompilationSuccessful(compileResult);
+	}
+
+	@Test
+	public void originalAppInManifestDoesNotCompile() throws IOException {
+		addManifestProcessorParameter(InstantRunManifestTest.class, "IncorrectInstantRunManifest.xml");
+
+		CompileResult compileResult = compileFiles(MyApplication.class);
+
+		assertCompilationErrorOn(MyApplication.class, "@EApplication", compileResult);
+	}
+
+}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/manifest/MyApplication.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/manifest/MyApplication.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.manifest;
+
+import org.androidannotations.annotations.EApplication;
+
+import android.app.Application;
+
+@EApplication
+public class MyApplication extends Application {
+}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/resources/org/androidannotations/manifest/CorrectInstantRunManifest.xml
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/resources/org/androidannotations/manifest/CorrectInstantRunManifest.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License. You may obtain a copy of
+    the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed To in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.androidannotations.testprocessor"
+    android:versionCode="1"
+    android:versionName="1.0" >
+    
+    <application
+        android:name="com.android.tools.fd.runtime.BootstrapApplication"
+        name="org.androidannotations.manifest.MyApplication_" />
+
+</manifest>

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/resources/org/androidannotations/manifest/IncorrectInstantRunManifest.xml
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/resources/org/androidannotations/manifest/IncorrectInstantRunManifest.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright (C) 2010-2015 eBusiness Information, Excilys Group
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License. You may obtain a copy of
+    the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed To in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.androidannotations.testprocessor"
+    android:versionCode="1"
+    android:versionName="1.0" >
+    
+    <application
+        android:name="com.android.tools.fd.runtime.BootstrapApplication"
+        name="org.androidannotations.manifest.MyApplication" />
+
+</manifest>


### PR DESCRIPTION
Instant Run swaps the application class name in the manifest to its own
bootstrap application, which can instrument the app to use instant Run.
It also adds a new "name" attribute to the manifest, which contains the
original application. When Instant Run is used, we should retrieve this
attribute as the application class name.

Related to #1697.