### PR TITLE
Fix @InstanceState calling order

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations-test/src/main/java/org/androidannotations/test/instancestate/InstanceStateAfterInjectActivity.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-test/src/main/java/org/androidannotations/test/instancestate/InstanceStateAfterInjectActivity.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test.instancestate;
+
+import org.androidannotations.annotations.AfterInject;
+import org.androidannotations.annotations.EActivity;
+import org.androidannotations.annotations.InstanceState;
+
+import android.app.Activity;
+
+@EActivity
+public class InstanceStateAfterInjectActivity extends Activity {
+
+	@InstanceState
+	int instanceField = -1;
+
+	int restoredInAfterInject;
+
+	@AfterInject
+	void afterInject() {
+		restoredInAfterInject = instanceField;
+	}
+}

--- a/AndroidAnnotations/androidannotations-core/androidannotations-test/src/test/java/org/androidannotations/test/instancestate/InstanceStateAfterInjectActivityTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-test/src/test/java/org/androidannotations/test/instancestate/InstanceStateAfterInjectActivityTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.test.instancestate;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+import android.os.Bundle;
+
+@RunWith(RobolectricTestRunner.class)
+public class InstanceStateAfterInjectActivityTest {
+
+	@Test
+	public void testInstanceStateAfterInjectCallOrder() {
+		int restoredValue = 42;
+
+		Bundle bundle = new Bundle();
+		bundle.putInt("instanceField", restoredValue);
+
+		InstanceStateAfterInjectActivity_ activity = Robolectric.buildActivity(InstanceStateAfterInjectActivity_.class).create(bundle).get();
+
+		assertThat(activity.restoredInAfterInject).isEqualTo(restoredValue);
+	}
+}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/InstanceStateDelegate.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/InstanceStateDelegate.java
@@ -82,14 +82,10 @@ public class InstanceStateDelegate extends GeneratedClassHolderDelegate<ECompone
 	private void setRestoreStateMethod() {
 		restoreStateMethod = getGeneratedClass().method(PRIVATE, codeModel().VOID, "restoreSavedInstanceState" + generationSuffix());
 		restoreStateBundleParam = restoreStateMethod.param(getClasses().BUNDLE, "savedInstanceState");
-		getInit().body().invoke(restoreStateMethod).arg(restoreStateBundleParam);
+		holder.getInitBodyInjectionBlock().invoke(restoreStateMethod).arg(restoreStateBundleParam);
 
 		restoreStateMethod.body() //
 				._if(ref("savedInstanceState").eq(_null())) //
 				._then()._return();
-	}
-
-	public JMethod getInit() {
-		return holder.getInit();
 	}
 }


### PR DESCRIPTION
In some scenarios, state restoration was called after `@AfterInject`
methods are called. This commit fixes this issue by moving the restore
call to the dedicated injection block.

Fixes #1703.