### PR TITLE
Make members in Kotlin example protected

### DIFF
--- a/examples/kotlin/src/main/kotlin/org/androidannotations/gradle/activity/HelloAndroidActivity.kt
+++ b/examples/kotlin/src/main/kotlin/org/androidannotations/gradle/activity/HelloAndroidActivity.kt
@@ -21,12 +21,12 @@ open public class HelloAndroidActivity : Activity() {
     protected lateinit var helloTextView: TextView
 
     @AfterViews
-    protected fun afterViews(): Unit {
+    protected fun afterViews() {
         computeDateBackground()
     }
 
     @Background
-    protected open fun computeDateBackground(): Unit {
+    protected open fun computeDateBackground() {
         val now = Date()
         val helloMessage = String.format(hello, now.toString())
 
@@ -34,7 +34,7 @@ open public class HelloAndroidActivity : Activity() {
     }
 
     @UiThread
-    protected open fun updateHelloTextView(helloMessage: String): Unit {
+    protected open fun updateHelloTextView(helloMessage: String) {
         helloTextView.text = helloMessage
     }
 }

--- a/examples/kotlin/src/main/kotlin/org/androidannotations/gradle/activity/HelloAndroidActivity.kt
+++ b/examples/kotlin/src/main/kotlin/org/androidannotations/gradle/activity/HelloAndroidActivity.kt
@@ -15,18 +15,18 @@ import java.util.Date
 open public class HelloAndroidActivity : Activity() {
 
     @StringRes
-    lateinit var hello: String
+    protected lateinit var hello: String
 
     @ViewById
-    lateinit var helloTextView: TextView
+    protected lateinit var helloTextView: TextView
 
     @AfterViews
-    fun afterViews(): Unit {
+    protected fun afterViews(): Unit {
         computeDateBackground()
     }
 
     @Background
-    open fun computeDateBackground(): Unit {
+    protected open fun computeDateBackground(): Unit {
         val now = Date()
         val helloMessage = String.format(hello, now.toString())
 
@@ -34,7 +34,7 @@ open public class HelloAndroidActivity : Activity() {
     }
 
     @UiThread
-    open fun updateHelloTextView(helloMessage: String): Unit {
+    protected open fun updateHelloTextView(helloMessage: String): Unit {
         helloTextView.text = helloMessage
     }
 }


### PR DESCRIPTION
In Kotlin, the default visibility (no modifier) is public.
There is no equivalent modifier of package-private, so we must use protected.