### PR TITLE
Fixes RestTemplate generation with ResponseEntity as return type

### DIFF
--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/helper/RestAnnotationHelper.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring/src/main/java/org/androidannotations/rest/spring/helper/RestAnnotationHelper.java
@@ -367,9 +367,19 @@ public class RestAnnotationHelper extends TargetAnnotationHelper {
 		IJExpression responseClassExpr = nullCastedToNarrowedClass(holder);
 		TypeMirror returnType = executableElement.getReturnType();
 		if (returnType.getKind() != TypeKind.VOID) {
-			if (getElementUtils().getTypeElement(RestSpringClasses.PARAMETERIZED_TYPE_REFERENCE) != null && !returnType.toString().startsWith(RestSpringClasses.RESPONSE_ENTITY)
-					&& checkIfParameterizedTypeReferenceShouldBeUsed(returnType)) {
-				return createParameterizedTypeReferenceAnonymousSubclassInstance(returnType);
+			if (getElementUtils().getTypeElement(RestSpringClasses.PARAMETERIZED_TYPE_REFERENCE) != null) {
+				if (returnType.toString().startsWith(RestSpringClasses.RESPONSE_ENTITY)) {
+
+					List<? extends TypeMirror> typeArguments = ((DeclaredType) returnType).getTypeArguments();
+
+					if (!typeArguments.isEmpty()) {
+						returnType = typeArguments.get(0);
+					}
+				}
+
+				if (checkIfParameterizedTypeReferenceShouldBeUsed(returnType)) {
+					return createParameterizedTypeReferenceAnonymousSubclassInstance(returnType);
+				}
 			}
 
 			AbstractJClass responseClass = retrieveResponseClass(returnType, holder);


### PR DESCRIPTION
Implements #1735 

Some test are missing because ParameterizedTypeReference is only available in Spring Android Rest Template 2.0.
I tested it locally.