### PR TITLE
Fix enabling/disabling annotations

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/CorePlugin.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/CorePlugin.java
@@ -219,9 +219,7 @@ public class CorePlugin extends AndroidAnnotationsPlugin {
 		annotationHandlers.add(new PreferenceClickHandler(androidAnnotationEnv));
 		annotationHandlers.add(new AfterPreferencesHandler(androidAnnotationEnv));
 
-		if (androidAnnotationEnv.getOptionBooleanValue(OPTION_TRACE)) {
-			annotationHandlers.add(new TraceHandler(androidAnnotationEnv));
-		}
+		annotationHandlers.add(new TraceHandler(androidAnnotationEnv, androidAnnotationEnv.getOptionBooleanValue(OPTION_TRACE)));
 
 		/*
 		 * WakeLockHandler must be after TraceHandler but before UiThreadHandler
@@ -240,10 +238,8 @@ public class CorePlugin extends AndroidAnnotationsPlugin {
 		 * SupposeUiThreadHandler and SupposeBackgroundHandler must be after all
 		 * handlers that modifies generated method body
 		 */
-		if (androidAnnotationEnv.getOptionBooleanValue(OPTION_THREAD_CONTROL)) {
-			annotationHandlers.add(new SupposeUiThreadHandler(androidAnnotationEnv));
-			annotationHandlers.add(new SupposeBackgroundHandler(androidAnnotationEnv));
-		}
+		annotationHandlers.add(new SupposeUiThreadHandler(androidAnnotationEnv, androidAnnotationEnv.getOptionBooleanValue(OPTION_THREAD_CONTROL)));
+		annotationHandlers.add(new SupposeBackgroundHandler(androidAnnotationEnv, androidAnnotationEnv.getOptionBooleanValue(OPTION_THREAD_CONTROL)));
 
 		return annotationHandlers;
 	}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/SupposeBackgroundHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/SupposeBackgroundHandler.java
@@ -34,12 +34,16 @@ public class SupposeBackgroundHandler extends SupposeThreadHandler {
 
 	private static final String METHOD_CHECK_BG_THREAD = "checkBgThread";
 
-	public SupposeBackgroundHandler(AndroidAnnotationsEnvironment environment) {
-		super(SupposeBackground.class, environment);
+	public SupposeBackgroundHandler(AndroidAnnotationsEnvironment environment, boolean enabled) {
+		super(SupposeBackground.class, environment, enabled);
 	}
 
 	@Override
 	public void process(Element element, EComponentHolder holder) throws Exception {
+		if (!enabled) {
+			return;
+		}
+
 		ExecutableElement executableElement = (ExecutableElement) element;
 
 		JMethod delegatingMethod = codeModelHelper.overrideAnnotatedMethod(executableElement, holder);

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/SupposeThreadHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/SupposeThreadHandler.java
@@ -24,12 +24,19 @@ import org.androidannotations.holder.EComponentHolder;
 
 public abstract class SupposeThreadHandler extends BaseAnnotationHandler<EComponentHolder> {
 
-	public SupposeThreadHandler(Class<?> targetClass, AndroidAnnotationsEnvironment environment) {
+	boolean enabled;
+
+	public SupposeThreadHandler(Class<?> targetClass, AndroidAnnotationsEnvironment environment, boolean enabled) {
 		super(targetClass, environment);
+		this.enabled = enabled;
 	}
 
 	@Override
 	protected void validate(Element element, ElementValidation valid) {
+		if (!enabled) {
+			return;
+		}
+
 		validatorHelper.enclosingElementHasEnhancedComponentAnnotation(element, valid);
 		validatorHelper.isNotPrivate(element, valid);
 		validatorHelper.isNotFinal(element, valid);

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/SupposeUiThreadHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/SupposeUiThreadHandler.java
@@ -31,12 +31,16 @@ public class SupposeUiThreadHandler extends SupposeThreadHandler {
 
 	private static final String METHOD_CHECK_UI_THREAD = "checkUiThread";
 
-	public SupposeUiThreadHandler(AndroidAnnotationsEnvironment environment) {
-		super(SupposeUiThread.class, environment);
+	public SupposeUiThreadHandler(AndroidAnnotationsEnvironment environment, boolean enabled) {
+		super(SupposeUiThread.class, environment, enabled);
 	}
 
 	@Override
 	public void process(Element element, EComponentHolder holder) throws Exception {
+		if (!enabled) {
+			return;
+		}
+
 		ExecutableElement executableElement = (ExecutableElement) element;
 
 		JMethod delegatingMethod = codeModelHelper.overrideAnnotatedMethod(executableElement, holder);

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/TraceHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/TraceHandler.java
@@ -48,12 +48,20 @@ import com.helger.jcodemodel.JVar;
 
 public class TraceHandler extends BaseAnnotationHandler<EComponentHolder> {
 
-	public TraceHandler(AndroidAnnotationsEnvironment environment) {
+	private boolean enabled;
+
+	public TraceHandler(AndroidAnnotationsEnvironment environment, boolean enabled) {
 		super(Trace.class, environment);
+		this.enabled = enabled;
 	}
 
 	@Override
 	public void validate(Element element, ElementValidation validation) {
+		if (!enabled) {
+			return;
+		}
+
+
 		validatorHelper.enclosingElementHasEnhancedComponentAnnotation(element, validation);
 
 		validatorHelper.isNotPrivate(element, validation);
@@ -63,6 +71,10 @@ public class TraceHandler extends BaseAnnotationHandler<EComponentHolder> {
 
 	@Override
 	public void process(Element element, EComponentHolder holder) throws Exception {
+		if (!enabled) {
+			return;
+		}
+
 		ExecutableElement executableElement = (ExecutableElement) element;
 
 		String tag = extractTag(executableElement);


### PR DESCRIPTION
Fixes #1750 .

@dodgex can you take a look? I wonder, we may want to introduce a new method in the handler interface for this (`isEnabled()`), which has a `true` default implementation in the base classes.