### PR TITLE
Fix @Background serial execution

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/api/BackgroundExecutor.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/api/BackgroundExecutor.java
@@ -133,7 +133,7 @@ public final class BackgroundExecutor {
 			task.executionAsked = true;
 			future = directExecute(task, task.remainingDelay);
 		}
-		if ((task.id != null || task.serial != null) && !task.managed.get()) {
+		if (task.id != null || task.serial != null) {
 			/* keep task */
 			task.future = future;
 			TASKS.add(task);

--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/api/BackgroundExecutor.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/api/BackgroundExecutor.java
@@ -128,15 +128,13 @@ public final class BackgroundExecutor {
 	 *             executor)
 	 */
 	public static synchronized void execute(Task task) {
-		Future<?> future = null;
-		if (task.serial == null || !hasSerialRunning(task.serial)) {
-			task.executionAsked = true;
-			future = directExecute(task, task.remainingDelay);
-		}
 		if (task.id != null || task.serial != null) {
 			/* keep task */
-			task.future = future;
 			TASKS.add(task);
+		}
+		if (task.serial == null || !hasSerialRunning(task.serial)) {
+			task.executionAsked = true;
+			task.future = directExecute(task, task.remainingDelay);
 		}
 	}
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations-test/src/test/java/org/androidannotations/test/ThreadActivityTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-test/src/test/java/org/androidannotations/test/ThreadActivityTest.java
@@ -163,6 +163,31 @@ public class ThreadActivityTest {
 		}
 	}
 
+	@Test
+	public void serializedBackgroundTasksAsynchronous() throws InterruptedException {
+		/* set an executor with 4 threads */
+		BackgroundExecutor.setExecutor(Executors.newFixedThreadPool(4));
+
+		testSerializedBackgroundTasks();
+	}
+
+	@Test
+	public void serializedBackgroundTasksSynchronous() throws InterruptedException {
+		/* set a synchronous executor */
+		BackgroundExecutor.setExecutor(new Executor() {
+			@Override
+			public void execute(Runnable command) {
+				try {
+					command.run();
+				} catch (RuntimeException ignored) {
+					// ignored
+				}
+			}
+		});
+
+		testSerializedBackgroundTasks();
+	}
+
 	/**
 	 * Verify that serialized background tasks are correctly serialized.
 	 *
@@ -173,13 +198,9 @@ public class ThreadActivityTest {
 	 * Once all tasks have completed execution, verify that the items in the
 	 * list are ordered.
 	 */
-	@Test
-	public void serializedBackgroundTasks() {
+	private void testSerializedBackgroundTasks() {
 		/* number of items to add to the list */
 		final int NB_ADD = 10;
-
-		/* set an executor with 4 threads */
-		BackgroundExecutor.setExecutor(Executors.newFixedThreadPool(4));
 
 		/*
 		 * the calls are serialized, but not necessarily on the same thread, so


### PR DESCRIPTION
Revert the commit provided to fix the issue https://github.com/excilys/androidannotations/issues/1689 because it broke the serial execution of background tasks. This fixes #1775.

Then provide another commit, that fixes #1689.

See commit messages for details.