### PR TITLE
Update docs to include @Path annotation

### DIFF
--- a/AndroidAnnotations/androidannotations-rest-spring/rest-spring-api/src/main/java/org/androidannotations/rest/spring/annotations/Post.java
+++ b/AndroidAnnotations/androidannotations-rest-spring/rest-spring-api/src/main/java/org/androidannotations/rest/spring/annotations/Post.java
@@ -44,7 +44,7 @@ import java.lang.annotation.Target;
  * 	Event newEvent();
  * 
  * 	&#064;Post(&quot;/events/new/<b>{id}</b>&quot;)
- * 	void newEvent(&#064;Body Event <i>event</i>, int <b>id</b>);
+ * 	void newEvent(&#064;Body Event <i>event</i>, &#064;Path int <b>id</b>);
  * }
  * </pre>
  * 


### PR DESCRIPTION
As part of 4.0.0 all rest method params now need annotations.  This adds the @Path annotation to the docs for @Post