### PR TITLE
1847 fix method injection for resources

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentHolder.java
@@ -104,7 +104,7 @@ public abstract class EComponentHolder extends BaseGeneratedClassHolder {
 	}
 
 	private void setResourcesRef() {
-		resourcesRef = getInitBodyInjectionBlock().decl(getClasses().RESOURCES, "resources" + generationSuffix(), getContextRef().invoke("getResources"));
+		resourcesRef = getInitBodyBeforeInjectionBlock().decl(getClasses().RESOURCES, "resources" + generationSuffix(), getContextRef().invoke("getResources"));
 	}
 
 	public JFieldVar getPowerManagerRef() {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentHolder.java
@@ -34,6 +34,7 @@ public abstract class EComponentHolder extends BaseGeneratedClassHolder {
 
 	protected IJExpression contextRef;
 	protected JMethod init;
+	private JBlock initBodyBeforeInjectionBlock;
 	private JBlock initBodyInjectionBlock;
 	private JBlock initBodyAfterInjectionBlock;
 	private JVar resourcesRef;
@@ -81,7 +82,16 @@ public abstract class EComponentHolder extends BaseGeneratedClassHolder {
 		return initBodyAfterInjectionBlock;
 	}
 
+	public JBlock getInitBodyBeforeInjectionBlock() {
+		if (initBodyBeforeInjectionBlock == null) {
+			setInitBodyBlocks();
+		}
+
+		return initBodyBeforeInjectionBlock;
+	}
+
 	private void setInitBodyBlocks() {
+		initBodyBeforeInjectionBlock = getInitBody().blockVirtual();
 		initBodyInjectionBlock = getInitBody().blockVirtual();
 		initBodyAfterInjectionBlock = getInitBody().blockVirtual();
 	}


### PR DESCRIPTION
This PR should fix https://github.com/excilys/androidannotations/issues/1847 by always setting the resourcesRef (`resoruces_`) before trying to inject the resources itself.